### PR TITLE
nb cell errors will result in raising a PapermillExecutionError

### DIFF
--- a/papermill/__init__.py
+++ b/papermill/__init__.py
@@ -5,5 +5,5 @@ __version__ = get_versions()['version']
 del get_versions
 
 from papermill.api import display, record, read_notebook, read_notebooks
-from papermill.exceptions import PapermillException
+from papermill.exceptions import PapermillException, PapermillExecutionError
 from papermill.execute import execute_notebook

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -20,7 +20,7 @@ class PapermillExecutionError(PapermillException):
         self.evalue = evalue
         self.traceback = traceback
         message = "\n" + 75 * "-" + "\n"
-        message += "Exception encountered at Out [%s]:\n" % str(exec_count)
+        message += 'Exception encountered at "In [%s]":\n' % str(exec_count)
         for line in traceback:
             message += line + "\n"
         message += "\n"

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -9,3 +9,20 @@ class FileExistsError(AwsError):
 
 class PapermillException(Exception):
     """Raised when an exception is encountered when operating on a notebook."""
+
+
+class PapermillExecutionError(PapermillException):
+    """Raised when an exception is encountered in a notebook."""
+    def __init__(self, exec_count, source, ename, evalue, traceback):
+        self.exec_count = exec_count
+        self.source = source
+        self.ename = ename
+        self.evalue = evalue
+        self.traceback = traceback
+        message = "\n" + 75 * "-" + "\n"
+        message += "Exception encountered at Out [%s]:\n" % str(exec_count)
+        for line in traceback:
+            message += line + "\n"
+        message += "\n"
+
+        super(PapermillExecutionError, self).__init__(message)

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -222,5 +222,6 @@ def raise_for_execution_errors(nb):
                     evalue=output.evalue,
                     traceback=output.traceback
                 )
+            break
     if error:
         raise error

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -6,6 +6,7 @@ import unittest
 
 from papermill.api import read_notebook
 from papermill.execute import execute_notebook
+from papermill.exceptions import PapermillExecutionError
 from tests import get_notebook_path
 
 
@@ -36,7 +37,8 @@ class TestBrokenNotebook(unittest.TestCase):
     def test(self):
         path = get_notebook_path('broken.ipynb')
         result_path = os.path.join(self.test_dir, 'broken.ipynb')
-        execute_notebook(path, result_path)
+        with self.assertRaises(PapermillExecutionError):
+            execute_notebook(path, result_path)
         nb = read_notebook(result_path)
         self.assertEqual(nb.node.cells[0].execution_count, 1)
         self.assertEqual(nb.node.cells[1].execution_count, 2)


### PR DESCRIPTION
A notebook cell execution error will result in the notebook saving to disk as well as PapermillExcecutionError being raised. The PapermillExecutionError will output both it's own traceback as well as the traceback for the cell that had the exception.