### PR TITLE
Handle cells without outputs when checking for exec errors.

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -213,6 +213,9 @@ def raise_for_execution_errors(nb):
 
     error = None
     for cell in nb.cells:
+        if not hasattr(cell, "objects"):
+            continue
+
         for output in cell.outputs:
             if output.output_type == "error":
                 error = PapermillExecutionError(

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -213,7 +213,7 @@ def raise_for_execution_errors(nb):
 
     error = None
     for cell in nb.cells:
-        if not hasattr(cell, "objects"):
+        if not hasattr(cell, "outputs"):
             continue
 
         for output in cell.outputs:


### PR DESCRIPTION
Need to handle cells that don't have outputs when checking for execution errors.