### PR TITLE
Removing * and replacing with papermill field 'status'

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -58,7 +58,7 @@ def preprocess(self, nb, resources):
     with futures.ThreadPoolExecutor(max_workers=1) as executor:
         for index, cell in enumerate(nb.cells):
             if hasattr(cell, "execution_count"):
-                cell.execution_count = "*"
+                cell.execution_count = None
             future = executor.submit(write_ipynb, nb, output_path)
             t0 = datetime.datetime.utcnow()
             try:


### PR DESCRIPTION
Setting the execution count to "\*" is a violation of the ipynb format and causing bugs in papermill and when trying to open partially complete notebooks in jupyter. The goal of using "\*" was so users could open running notebooks and see what cell papermill was currently running. This PR moves away from the "\*" execution count value in favor of updating a status field in the papermill metadata (i.e. node.metadata.papermill.status). We can then choose down the road how to use the status field for tools like commuter to indicate which cell is being run without violating the notebook spec.