### PR TITLE
Error message at top of notebook if exception encountered.

### DIFF
--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -40,7 +40,7 @@ class TestBrokenNotebook(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = read_notebook(result_path)
-        self.assertEqual(nb.node.cells[0].execution_count, 1)
-        self.assertEqual(nb.node.cells[1].execution_count, 2)
-        self.assertEqual(nb.node.cells[1].outputs[0].output_type, 'error')
-        self.assertEqual(nb.node.cells[2].execution_count, None)
+        self.assertFalse(hasattr(nb.node.cells[1], "execution_count"))
+        self.assertEqual(nb.node.cells[2].execution_count, 2)
+        self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'error')
+        self.assertEqual(nb.node.cells[3].execution_count, None)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -40,7 +40,8 @@ class TestBrokenNotebook(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = read_notebook(result_path)
-        self.assertFalse(hasattr(nb.node.cells[1], "execution_count"))
+        self.assertEqual(nb.node.cells[0].cell_type, "markdown")
+        self.assertEqual(nb.node.cells[1].execution_count, 1)
         self.assertEqual(nb.node.cells[2].execution_count, 2)
         self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'error')
         self.assertEqual(nb.node.cells[3].execution_count, None)


### PR DESCRIPTION
Many users are confused when their notebook fails as to whether it is an issue or with papermill. This "banner" will be rendered whenever there is a notebook generated exception.