### PR TITLE
Simplify naming of cli options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ Execute via the Python API
    import papermill as pm
 
    pm.execute_notebook(
-      src = 'path/to/input.ipynb',
-      dst = 'path/to/output.ipynb',
+      'path/to/input.ipynb',
+      'path/to/output.ipynb',
       parameters = dict(alpha=0.6, ratio=0.1)
    )
 

--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ Execute via the Python API
    import papermill as pm
 
    pm.execute_notebook(
-      notebook_path = 'path/to/input.ipynb',
-      output_path = 'path/to/output.ipynb',
+      source = 'path/to/input.ipynb',
+      dest = 'path/to/output.ipynb',
       parameters = dict(alpha=0.6, ratio=0.1)
    )
 
@@ -82,7 +82,7 @@ Amazon S3 account:
    $ papermill local/input.ipynb s3://bkt/output.ipynb -p alpha 0.6 -p l1_ratio 0.1
 
 
-.. _PythonBinding: 
+.. _PythonBinding:
 
 Python In-notebook Bindings
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ Execute via the Python API
    import papermill as pm
 
    pm.execute_notebook(
-      source = 'path/to/input.ipynb',
-      dest = 'path/to/output.ipynb',
+      src = 'path/to/input.ipynb',
+      dst = 'path/to/output.ipynb',
       parameters = dict(alpha=0.6, ratio=0.1)
    )
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """Main `papermill` interface."""
 
 import base64
@@ -12,55 +11,58 @@ from papermill.iorw import read_yaml_file
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('src')
-@click.argument('dst')
+@click.argument('notebook_path')
+@click.argument('output_path')
 @click.option(
-    '--param', '-p',
+    '--parameters', '-p',
     help='Parameters to pass to the parameters cell.',
     multiple=True, nargs=2
 )
 @click.option(
-    '--raw_param', '-r',
+    '--parameters_raw', '-r',
     help='Parameters to be read as raw string.',
     multiple=True, nargs=2
 )
 @click.option(
-    '--file_param', '-f',
+    '--parameters_file', '-f',
     help='Path to YAML file containing parameters.'
 )
 @click.option(
-    '--yaml_param', '-y',
+    '--parameters_yaml', '-y',
     help='YAML string to be used as parameters.'
 )
 @click.option(
-    '--base64_param', '-b',
+    '--parameters_base64', '-b',
     help='Base64 encoded YAML string as parameters.'
 )
 @click.option(
     '--kernel', '-k',
     help='Name of kernel to run.'
 )
-def papermill(
-             src, dst,
-             param, raw_param,
-             file_param, yaml_param, base64_param,
-             kernel):
-    """Utility for executing a single notebook on a container."""
-    if base64_param:
-        param_final = yaml.load(base64.b64decode(base64_param))
-    elif yaml_param:
-        param_final = yaml.load(yaml_param)
-    elif file_param:
-        param_final = read_yaml_file(file_param)
+def papermill(notebook_path, output_path, parameters, parameters_raw,
+              parameters_file, parameters_yaml, parameters_base64, kernel):
+    """Utility for executing a single notebook on a container.
+
+    Take a source notebook, apply parameters to the source notebook,
+    execute the notebook with the kernel specified, and save the
+    output in the destination notebook.
+
+    """
+    if parameters_base64:
+        parameters_final = yaml.load(base64.b64decode(parameters_base64))
+    elif parameters_yaml:
+        parameters_final = yaml.load(parameters_yaml)
+    elif parameters_file:
+        parameters_final = read_yaml_file(parameters_file)
     else:
         # Read in Parameters
-        param_final = {}
-        for name, value in param:
-            param_final[name] = _resolve_type(value)
-        for name, value in raw_param:
-            param_final[name] = value
+        parameters_final = {}
+        for name, value in parameters:
+            parameters_final[name] = _resolve_type(value)
+        for name, value in parameters_raw:
+            parameters_final[name] = value
 
-    execute_notebook(src, dst, param_final, kernel_name=kernel)
+    execute_notebook(notebook_path, output_path, parameters_final, kernel_name=kernel)
 
 
 def _resolve_type(value):

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -3,8 +3,10 @@
 """Main `papermill` interface."""
 
 import base64
+
 import click
 import yaml
+
 from papermill.execute import execute_notebook
 from papermill.iorw import read_yaml_file
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+"""Main `papermill` interface."""
+
 import base64
 import click
 import yaml
@@ -5,34 +9,56 @@ from papermill.execute import execute_notebook
 from papermill.iorw import read_yaml_file
 
 
-@click.command()
-@click.argument('notebook')
-@click.argument('output')
-@click.option('--parameters', '-p', help="Parameters to pass to the parameters cell.", multiple=True, nargs=2)
-@click.option('--raw_parameters', '-r', help="Parameters to be read as raw string.", multiple=True, nargs=2)
-@click.option('--parameters_file', '-f', help="Path to YAML file containing parameters.")
-@click.option('--parameters_yaml', '-y', help="YAML string to be used as parameters.")
-@click.option('--parameters_base64', '-b', help="Base64 encoded YAML string as parameters.")
-@click.option('--kernel', '-k', help="Kernel name to run the notebook with.")
-def papermill(notebook, output, parameters, raw_parameters, parameters_file, parameters_yaml, parameters_base64,
-              kernel):
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('src')
+@click.argument('dest')
+@click.option(
+    '--param', '-p',
+    help='Parameters to pass to the parameters cell.',
+    multiple=True, nargs=2
+)
+@click.option(
+    '--raw_param', '-r',
+    help='Parameters to be read as raw string.',
+    multiple=True, nargs=2
+)
+@click.option(
+    '--file_param', '-f',
+    help='Path to YAML file containing parameters.'
+)
+@click.option(
+    '--yaml_param', '-y',
+    help='YAML string to be used as parameters.'
+)
+@click.option(
+    '--base64_param', '-b',
+    help='Base64 encoded YAML string as parameters.'
+)
+@click.option(
+    '--kernel', '-k',
+    help='Name of kernel to run.'
+)
+def papermill(
+             src, dest,
+             param, raw_param,
+             file_param, yaml_param, base64_param,
+             kernel):
     """Utility for executing a single notebook on a container."""
-    if parameters_base64:
-        parameters_final = yaml.load(base64.b64decode(parameters_base64))
-    elif parameters_yaml:
-        parameters_final = yaml.load(parameters_yaml)
-    elif parameters_file:
-        parameters_final = read_yaml_file(parameters_file)
+    if base64_param:
+        param_final = yaml.load(base64.b64decode(base64_param))
+    elif yaml_param:
+        param_final = yaml.load(yaml_param)
+    elif file_param:
+        param_final = read_yaml_file(file_param)
     else:
         # Read in Parameters
-        parameters_final = {}
-        for name, value in parameters:
-            parameters_final[name] = _resolve_type(value)
-        for name, value in raw_parameters:
-            parameters_final[name] = value
+        param_final = {}
+        for name, value in param:
+            param_final[name] = _resolve_type(value)
+        for name, value in raw_param:
+            param_final[name] = value
 
-    # Notebook Execution
-    execute_notebook(notebook, output, parameters_final, kernel_name=kernel)
+    execute_notebook(src, dest, param_final, kernel_name=kernel)
 
 
 def _resolve_type(value):
@@ -66,5 +92,5 @@ def _is_float(value):
     return "." in value
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     papermill()

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -9,9 +9,9 @@ from papermill.execute import execute_notebook
 from papermill.iorw import read_yaml_file
 
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.command()
 @click.argument('src')
-@click.argument('dest')
+@click.argument('dst')
 @click.option(
     '--param', '-p',
     help='Parameters to pass to the parameters cell.',
@@ -39,7 +39,7 @@ from papermill.iorw import read_yaml_file
     help='Name of kernel to run.'
 )
 def papermill(
-             src, dest,
+             src, dst,
              param, raw_param,
              file_param, yaml_param, base64_param,
              kernel):
@@ -58,7 +58,7 @@ def papermill(
         for name, value in raw_param:
             param_final[name] = value
 
-    execute_notebook(src, dest, param_final, kernel_name=kernel)
+    execute_notebook(src, dst, param_final, kernel_name=kernel)
 
 
 def _resolve_type(value):

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -9,7 +9,7 @@ from papermill.execute import execute_notebook
 from papermill.iorw import read_yaml_file
 
 
-@click.command()
+@click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('src')
 @click.argument('dst')
 @click.option(


### PR DESCRIPTION
- simplify naming (parameters -> param)
- make long and short name of options consistent with leading letter (`--file_param`, `-f`)
- add help options
- change to `src` and `dst` since greater clarity than `notebook` and `output`