### PR TITLE
using regex to remove ansi escape for colors

### DIFF
--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -1,3 +1,5 @@
+import re
+
 
 class AwsError(Exception):
     """Raised when an AWS Exception is encountered."""
@@ -21,8 +23,11 @@ class PapermillExecutionError(PapermillException):
         self.traceback = traceback
         message = "\n" + 75 * "-" + "\n"
         message += 'Exception encountered at "In [%s]":\n' % str(exec_count)
+        tb = ""
         for line in traceback:
-            message += line + "\n"
+            tb += line + "\n"
+        ansi_escape = re.compile(r'\x1b[^m]*m')
+        message += ansi_escape.sub('', tb)
         message += "\n"
 
         super(PapermillExecutionError, self).__init__(message)

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -1,4 +1,4 @@
-import re
+from ansiwrap import strip_color
 
 
 class AwsError(Exception):
@@ -23,11 +23,7 @@ class PapermillExecutionError(PapermillException):
         self.traceback = traceback
         message = "\n" + 75 * "-" + "\n"
         message += 'Exception encountered at "In [%s]":\n' % str(exec_count)
-        tb = ""
-        for line in traceback:
-            tb += line + "\n"
-        ansi_escape = re.compile(r'\x1b[^m]*m')
-        message += ansi_escape.sub('', tb)
+        message += strip_color("\n".join(traceback))
         message += "\n"
 
         super(PapermillExecutionError, self).__init__(message)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='papermill',
       url='https://github.com/nteract/papermill',
       packages=['papermill'],
       install_requires=[
+          'ansiwrap',
           'boto3',
           'click',
           'futures',


### PR DESCRIPTION
This removes the color escape chars so that it doesn't muddy up the exception outputs.