### PR TITLE
omit the versioneer script

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = False
 omit =
     papermill/tests/*
+    papermill/_version.py
 
 [report]
 exclude_lines =
@@ -13,3 +14,4 @@ ignore_errors = True
 omit =
     papermill/tests/*
     */site-packages/*
+    papermill/_version.py


### PR DESCRIPTION
The versioneer script comes from [python-versioneer](https://github.com/warner/python-versioneer) which is tested in its own repo. We don't want it to be part of our code coverage.