### PR TITLE
execution: add option to write notebook dataframe to disk as JSON

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -47,9 +47,13 @@ from papermill.iorw import read_yaml_file
     '--log-output/--no-log-output', default=False,
     help="Flag for writing notebook output to stderr."
 )
+@click.option(
+    '--dataframe-file','-d', default=False,
+    help="JSON representation of output dataframe"
+)
 def papermill(notebook_path, output_path, parameters, parameters_raw,
               parameters_file, parameters_yaml, parameters_base64, kernel,
-              progress_bar, log_output):
+              progress_bar, log_output, dataframe_file):
     """Utility for executing a single notebook on a container.
 
     Take a source notebook, apply parameters to the source notebook,
@@ -77,7 +81,8 @@ def papermill(notebook_path, output_path, parameters, parameters_raw,
         parameters_final,
         kernel_name=kernel,
         progress_bar=progress_bar,
-        log_output=log_output
+        log_output=log_output,
+        dataframe_file=dataframe_file
     )
 
 

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from papermill.conf import settings
 from papermill.exceptions import PapermillException, PapermillExecutionError
 from papermill.iorw import load_notebook_node, write_ipynb, read_yaml_file, get_pretty_path
+from papermill.api import read_notebook
 
 PENDING = "pending"
 RUNNING = "running"
@@ -125,7 +126,7 @@ def log_outputs(cell):
 Preprocessor.preprocess = preprocess
 
 
-def execute_notebook(notebook, output, parameters=None, kernel_name=None, progress_bar=True, log_output=False):
+def execute_notebook(notebook, output, parameters=None, kernel_name=None, progress_bar=True, log_output=False, dataframe_file=None):
     """Executes a single notebook locally.
 
     Args:
@@ -169,7 +170,10 @@ def execute_notebook(notebook, output, parameters=None, kernel_name=None, progre
     # Write final Notebook to disk.
     write_ipynb(nb, output)
     raise_for_execution_errors(nb, output)
-
+    if dataframe_file:
+        outputnb = read_notebook(output)
+        with open(dataframe_file,'w') as dfile:
+            dfile.write(outputnb.dataframe.to_json())
 
 def _parameterize_notebook(nb, kernel_name, parameters):
 


### PR DESCRIPTION
Hi,

papermill allows the notebook to attach arbitrary data during it's execution, it would be useful to be able to write that file to disk, so that it can be further manipulated by tools outside of the papermill ecosystem / outside of python even.

A similar option could be useful for the `.data` property (which seems to be a JSON'able dict

* adds an option in execute_notebook() to write dataframe to disk via pandas to_json() function
* adds corresponding CLI option --dataframe-file