### PR TITLE
[MRG] Swap order of test for `int` and `float`

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -88,10 +88,10 @@ def _resolve_type(value):
         return False
     elif value == "None":
         return None
-    elif _is_float(value):
-        return float(value)
     elif _is_int(value):
         return int(value)
+    elif _is_float(value):
+        return float(value)
     else:
         return value
 

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -12,10 +12,8 @@ from ..cli import _is_int,  _is_float, _resolve_type
     ("True", True),
     ("False", False),
     ("None", None),
-    (13.3, 13.3),
     ("12.51", 12.51),
-    (10, 10.0),
-    ("10", 10.0),
+    ("10", 10),
     ("hello world", "hello world"),
     (u"😍", u"😍"),
 ])


### PR DESCRIPTION
Every int is also a float, so checking for float first means we never
create any integers.