### PR TITLE
rely on __future__'s unicode_literals

### DIFF
--- a/papermill/api.py
+++ b/papermill/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 
 import pandas as pd
@@ -7,7 +8,6 @@ from six import string_types
 
 from papermill.exceptions import PapermillException
 from papermill.iorw import load_notebook_node, list_notebook_files
-
 
 RECORD_OUTPUT_TYPE = 'application/papermill.record+json'
 DISPLAY_OUTPUT_TYPE = 'application/papermill.display+json'
@@ -51,7 +51,8 @@ def read_notebook(path):
     """
     if not path.endswith(".ipynb"):
         raise PapermillException(
-            "Notebooks should have an '.ipynb' file extension. Provided path: '%s'", path)
+            "Notebooks should have an '.ipynb' file extension. Provided path: '%s'",
+            path)
 
     nb = Notebook()
     nb.path = path
@@ -77,8 +78,7 @@ def read_notebooks(path):
 
 
 class Notebook(object):
-
-    def __init__(self, node = None, path = None):
+    def __init__(self, node=None, path=None):
         """
         Args:
             node (nbformat.NotebookNode): a notebook object
@@ -107,7 +107,8 @@ class Notebook(object):
 
     @property
     def environment_variables(self):
-        return _get_papermill_metadata(self.node, 'environment_variables', default={})
+        return _get_papermill_metadata(
+            self.node, 'environment_variables', default={})
 
     @property
     def data(self):
@@ -144,7 +145,8 @@ class Notebook(object):
         """Display the output from this notebook in the running notebook."""
         outputs = _get_notebook_outputs(self.node)
         if name not in outputs:
-            raise PapermillException("Output Name '%s' is not available in this notebook.")
+            raise PapermillException(
+                "Output Name '%s' is not available in this notebook.")
         output = outputs[name]
         ip_display(output.data, metadata=output.metadata, raw=True)
 
@@ -175,7 +177,6 @@ def _fetch_notebook_data(nb_node):
 
 
 class NotebookCollection(object):
-
     def __init__(self):
 
         self._notebooks = {}
@@ -187,7 +188,8 @@ class NotebookCollection(object):
 
         if not isinstance(value, Notebook):
             raise PapermillException(
-                "Value must either be a path string or a Papermill Notebook object. Found: '%s'" % str(type(value)))
+                "Value must either be a path string or a Papermill Notebook object. Found: '%s'"
+                % str(type(value)))
         self._notebooks[key] = value
 
     def __getitem__(self, key):

--- a/papermill/api.py
+++ b/papermill/api.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 import os
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Main `papermill` interface."""
 
+from __future__ import unicode_literals
 import base64
 
 import click
@@ -14,39 +15,34 @@ from papermill.iorw import read_yaml_file
 @click.argument('notebook_path')
 @click.argument('output_path')
 @click.option(
-    '--parameters', '-p',
+    '--parameters',
+    '-p',
     help='Parameters to pass to the parameters cell.',
-    multiple=True, nargs=2
-)
+    multiple=True,
+    nargs=2)
 @click.option(
-    '--parameters_raw', '-r',
+    '--parameters_raw',
+    '-r',
     help='Parameters to be read as raw string.',
-    multiple=True, nargs=2
-)
+    multiple=True,
+    nargs=2)
 @click.option(
-    '--parameters_file', '-f',
-    help='Path to YAML file containing parameters.'
-)
+    '--parameters_file', '-f', help='Path to YAML file containing parameters.')
 @click.option(
-    '--parameters_yaml', '-y',
-    help='YAML string to be used as parameters.'
-)
+    '--parameters_yaml', '-y', help='YAML string to be used as parameters.')
 @click.option(
-    '--parameters_base64', '-b',
-    help='Base64 encoded YAML string as parameters.'
-)
+    '--parameters_base64',
+    '-b',
+    help='Base64 encoded YAML string as parameters.')
+@click.option('--kernel', '-k', help='Name of kernel to run.')
 @click.option(
-    '--kernel', '-k',
-    help='Name of kernel to run.'
-)
+    '--progress-bar/--no-progress-bar',
+    default=True,
+    help="Flag for turning on the progress bar.")
 @click.option(
-    '--progress-bar/--no-progress-bar', default=True,
-    help="Flag for turning on the progress bar."
-)
-@click.option(
-    '--log-output/--no-log-output', default=False,
-    help="Flag for writing notebook output to stderr."
-)
+    '--log-output/--no-log-output',
+    default=False,
+    help="Flag for writing notebook output to stderr.")
 def papermill(notebook_path, output_path, parameters, parameters_raw,
               parameters_file, parameters_yaml, parameters_base64, kernel,
               progress_bar, log_output):
@@ -77,8 +73,7 @@ def papermill(notebook_path, output_path, parameters, parameters_raw,
         parameters_final,
         kernel_name=kernel,
         progress_bar=progress_bar,
-        log_output=log_output
-    )
+        log_output=log_output)
 
 
 def _resolve_type(value):

--- a/papermill/conf.py
+++ b/papermill/conf.py
@@ -1,15 +1,15 @@
 """Manages the Settings for Papermill"""
+from __future__ import unicode_literals
 
 
 class Settings(object):
 
-    __default_settings = {
-        'ENVIRONMENT_VARIABLES': []
-    }
+    __default_settings = {'ENVIRONMENT_VARIABLES': []}
 
     def __init__(self):
 
         for name, value in self.__default_settings.items():
             setattr(self, name, value)
+
 
 settings = Settings()

--- a/papermill/conf.py
+++ b/papermill/conf.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+ 
 """Manages the Settings for Papermill"""
 from __future__ import unicode_literals
 

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 from ansiwrap import strip_color

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from ansiwrap import strip_color
 
 
@@ -15,6 +17,7 @@ class PapermillException(Exception):
 
 class PapermillExecutionError(PapermillException):
     """Raised when an exception is encountered in a notebook."""
+
     def __init__(self, exec_count, source, ename, evalue, traceback):
         self.exec_count = exec_count
         self.source = source

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 import datetime

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 import os
 import sys
@@ -77,7 +79,8 @@ def preprocess(self, nb, resources):
                 if not cell.source:
                     continue
 
-                nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
+                nb.cells[index], resources = self.preprocess_cell(
+                    cell, resources, index)
                 cell.metadata['papermill']['exception'] = False
                 if self.log_output:
                     log_outputs(nb.cells[index])
@@ -89,7 +92,8 @@ def preprocess(self, nb, resources):
                 t1 = datetime.datetime.utcnow()
                 cell.metadata['papermill']['start_time'] = t0.isoformat()
                 cell.metadata['papermill']['end_time'] = t1.isoformat()
-                cell.metadata['papermill']['duration'] = (t1 - t0).total_seconds()
+                cell.metadata['papermill']['duration'] = (
+                    t1 - t0).total_seconds()
                 cell.metadata['papermill']['status'] = COMPLETED
                 future.result()
     return nb, resources
@@ -106,26 +110,31 @@ def log_outputs(cell):
     for output in cell.get("outputs", []):
         if output.output_type == "stream":
             if output.name == "stdout":
-                stdouts.append("".join(output.text))
+                stdouts.append(u"".join(output.text))
             elif output.name == "stderr":
-                stderrs.append("".join(output.text))
+                stderrs.append(u"".join(output.text))
         elif "data" in output and "text/plain" in output.data:
             stdouts.append(output.data['text/plain'])
 
     # Log stdouts
-    sys.stdout.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
-    sys.stdout.write("\n".join(stdouts) + "\n")
+    sys.stdout.write(u'{:-<40}'.format(u"Out [%s] " % execution_count) + u"\n")
+    sys.stdout.write(u"\n".join(stdouts) + u"\n")
 
     # Log stderrs
-    sys.stderr.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
-    sys.stderr.write("\n".join(stderrs) + "\n")
+    sys.stderr.write(u'{:-<40}'.format(u"Out [%s] " % execution_count) + u"\n")
+    sys.stderr.write(u"\n".join(stderrs) + u"\n")
 
 
 # Monkey Patch the base preprocess method.
 Preprocessor.preprocess = preprocess
 
 
-def execute_notebook(notebook, output, parameters=None, kernel_name=None, progress_bar=True, log_output=False):
+def execute_notebook(notebook,
+                     output,
+                     parameters=None,
+                     kernel_name=None,
+                     progress_bar=True,
+                     log_output=False):
     """Executes a single notebook locally.
 
     Args:
@@ -146,15 +155,15 @@ def execute_notebook(notebook, output, parameters=None, kernel_name=None, progre
 
     # Record specified environment variable values.
     nb.metadata.papermill['parameters'] = parameters
-    nb.metadata.papermill['environment_variables'] = _fetch_environment_variables()
+    nb.metadata.papermill[
+        'environment_variables'] = _fetch_environment_variables()
     nb.metadata.papermill['output_path'] = output
 
     # Execute the Notebook.
     t0 = datetime.datetime.utcnow()
     processor = ExecutePreprocessor(
         timeout=None,
-        kernel_name=kernel_name or nb.metadata.kernelspec.name,
-    )
+        kernel_name=kernel_name or nb.metadata.kernelspec.name, )
     processor.progress_bar = progress_bar
     processor.log_output = log_output
 
@@ -164,7 +173,8 @@ def execute_notebook(notebook, output, parameters=None, kernel_name=None, progre
     nb.metadata.papermill['start_time'] = t0.isoformat()
     nb.metadata.papermill['end_time'] = t1.isoformat()
     nb.metadata.papermill['duration'] = (t1 - t0).total_seconds()
-    nb.metadata.papermill['exception'] = any([cell.metadata.papermill.get('exception') for cell in nb.cells])
+    nb.metadata.papermill['exception'] = any(
+        [cell.metadata.papermill.get('exception') for cell in nb.cells])
 
     # Write final Notebook to disk.
     write_ipynb(nb, output)
@@ -198,8 +208,8 @@ def _build_parameter_code(kernel_name, parameters):
     elif kernelspec.language in _parameter_code_builders:
         return _parameter_code_builders[kernelspec.language](parameters)
     raise PapermillException(
-        "No parameter builder functions specified for kernel '%s' or language '%s'" % (kernel_name, kernelspec.language)
-    )
+        "No parameter builder functions specified for kernel '%s' or language '%s'"
+        % (kernel_name, kernelspec.language))
 
 
 def _find_parameters_index(nb):
@@ -220,9 +230,11 @@ _parameter_code_builders = {}
 
 def register_param_builder(name):
     """Decorator for registering functions that write variable assignments for a given kernel or language."""
+
     def wrapper(func):
         _parameter_code_builders[name] = func
         return func
+
     return wrapper
 
 
@@ -263,8 +275,7 @@ def _fetch_environment_variables():
 ERROR_MESSAGE_TEMPLATE = (
     '<span style="color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;">'
     "An Exception was encountered at 'In [%s]'."
-    '</span>'
-)
+    '</span>')
 
 
 def raise_for_execution_errors(nb, output_path):
@@ -281,8 +292,7 @@ def raise_for_execution_errors(nb, output_path):
                     source=cell.source,
                     ename=output.ename,
                     evalue=output.evalue,
-                    traceback=output.traceback
-                )
+                    traceback=output.traceback)
                 break
 
     if error:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -112,19 +112,19 @@ def log_outputs(cell):
     for output in cell.get("outputs", []):
         if output.output_type == "stream":
             if output.name == "stdout":
-                stdouts.append(u"".join(output.text))
+                stdouts.append("".join(output.text))
             elif output.name == "stderr":
-                stderrs.append(u"".join(output.text))
+                stderrs.append("".join(output.text))
         elif "data" in output and "text/plain" in output.data:
             stdouts.append(output.data['text/plain'])
 
     # Log stdouts
-    sys.stdout.write(u'{:-<40}'.format(u"Out [%s] " % execution_count) + u"\n")
-    sys.stdout.write(u"\n".join(stdouts) + u"\n")
+    sys.stdout.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
+    sys.stdout.write("\n".join(stdouts) + "\n")
 
     # Log stderrs
-    sys.stderr.write(u'{:-<40}'.format(u"Out [%s] " % execution_count) + u"\n")
-    sys.stderr.write(u"\n".join(stderrs) + u"\n")
+    sys.stderr.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
+    sys.stderr.write("\n".join(stderrs) + "\n")
 
 
 # Monkey Patch the base preprocess method.

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 import io

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import io
 import os
 
@@ -39,7 +41,6 @@ class PapermillIO(object):
 
 
 class LocalHandler(object):
-
     @classmethod
     def read(cls, path):
         with io.open(path, 'r') as f:
@@ -124,7 +125,8 @@ def load_notebook_node(notebook_path):
 
     for cell in nb.cells:
         if not hasattr(cell.metadata, 'tags'):
-            cell.metadata['tags'] = []  # Create tags attr if one doesn't exist.
+            cell.metadata['tags'] = [
+            ]  # Create tags attr if one doesn't exist.
 
         if not hasattr(cell.metadata, 'papermill'):
             cell.metadata['papermill'] = dict()

--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -1,3 +1,5 @@
+ # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 from concurrent import futures

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 """ Test the command line interface """
 
 import pytest
@@ -15,7 +17,7 @@ from ..cli import _is_int,  _is_float, _resolve_type
     ("12.51", 12.51),
     ("10", 10),
     ("hello world", "hello world"),
-    (u"😍", u"😍"),
+    ("😍", "😍"),
 ])
 def test_resolve_type(test_input, expected):
     assert _resolve_type(test_input) == expected


### PR DESCRIPTION
We ran into an issue where a user had some `!pip install` that had unicode output that wasn't being encoded and decoded properly. This switches the section of code that mixed string concatenation between Python 2 strings and unicode strings over to only using unicode strings. While I was at it I brought in `unicode_literals` from `__future__`.

/cc @mpacer @charsmith 