### PR TITLE
Add test for display function

### DIFF
--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -1,6 +1,10 @@
 import pytest
 import unittest
-from unittest.mock import patch
+import six
+if six.PY3:
+    from unittest.mock import patch
+else:
+    import mock
 
 import pandas as pd
 from pandas.util.testing import assert_frame_equal

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -4,7 +4,7 @@ import six
 if six.PY3:
     from unittest.mock import patch
 else:
-    import mock
+    from mock import patch
 
 import pandas as pd
 from pandas.util.testing import assert_frame_equal

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -6,6 +6,7 @@ import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
 from papermill import display, read_notebook, read_notebooks, PapermillException
+from papermill.api import Notebook
 from . import get_notebook_path, get_notebook_dir
 
 
@@ -35,6 +36,11 @@ class TestNotebookClass(unittest.TestCase):
 
         with self.assertRaises(PapermillException):
             read_notebook('result_notebook.py')
+
+    def test_path_without_node(self):
+
+        with self.assertRaises(ValueError):
+            Notebook(node=None, path='collection/result1.ipynb')
 
 
 class TestNotebookCollection(unittest.TestCase):

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -1,10 +1,11 @@
 import pytest
 import unittest
+from unittest.mock import patch
 
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
-from papermill import read_notebook, read_notebooks, PapermillException
+from papermill import display, read_notebook, read_notebooks, PapermillException
 from . import get_notebook_path, get_notebook_dir
 
 
@@ -71,3 +72,13 @@ class TestNotebookCollection(unittest.TestCase):
             columns=['filename', 'cell', 'value', 'type', 'key']
         )
         assert_frame_equal(nbs.metrics, expected_metrics_df)
+
+
+@patch('papermill.api.ip_display')
+@patch('IPython.core.formatters.format_display_data')
+def test_display(format_display_data_mock, ip_display_mock):
+    format_display_data_mock.return_value = ({'foo': 'bar'}, {'metadata': 'baz'})
+    display('display_name', {'display_obj': 'hello'})
+
+    format_display_data_mock.assert_called_once_with({'display_obj': 'hello'})
+    ip_display_mock.assert_called_once_with({'foo': 'bar'}, metadata={'metadata': 'baz', 'papermill': {'name': 'display_name'}}, raw=True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 codecov
 coverage
+mock ; python_version == '2.7'
 pytest
 pytest-cov


### PR DESCRIPTION
This adds 2 tests: One for the `display` function and another for initializing a Notebook with a path but no node specified.