### PR TITLE
Changed import paths to be relative; rather than a mix of relative and absolute

### DIFF
--- a/papermill/__init__.py
+++ b/papermill/__init__.py
@@ -4,6 +4,6 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-from papermill.api import display, record, read_notebook, read_notebooks
-from papermill.exceptions import PapermillException, PapermillExecutionError
-from papermill.execute import execute_notebook
+from .api import display, record, read_notebook, read_notebooks
+from .exceptions import PapermillException, PapermillExecutionError
+from .execute import execute_notebook

--- a/papermill/api.py
+++ b/papermill/api.py
@@ -8,8 +8,8 @@ import IPython
 from IPython.display import display as ip_display, Markdown
 from six import string_types
 
-from papermill.exceptions import PapermillException
-from papermill.iorw import load_notebook_node, list_notebook_files
+from .exceptions import PapermillException
+from .iorw import load_notebook_node, list_notebook_files
 
 RECORD_OUTPUT_TYPE = 'application/papermill.record+json'
 DISPLAY_OUTPUT_TYPE = 'application/papermill.display+json'

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -7,8 +7,8 @@ import base64
 import click
 import yaml
 
-from papermill.execute import execute_notebook
-from papermill.iorw import read_yaml_file
+from .execute import execute_notebook
+from .iorw import read_yaml_file
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -15,9 +15,9 @@ from nbconvert.preprocessors.base import Preprocessor
 from six import string_types
 from tqdm import tqdm
 
-from papermill.conf import settings
-from papermill.exceptions import PapermillException, PapermillExecutionError
-from papermill.iorw import load_notebook_node, write_ipynb, read_yaml_file, get_pretty_path
+from .conf import settings
+from .exceptions import PapermillException, PapermillExecutionError
+from .iorw import load_notebook_node, write_ipynb, read_yaml_file, get_pretty_path
 
 PENDING = "pending"
 RUNNING = "running"

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -8,8 +8,8 @@ import os
 import nbformat
 import yaml
 
-from papermill import __version__
-from papermill.s3 import S3
+from . import __version__
+from .s3 import S3
 
 
 class PapermillIO(object):

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -9,8 +9,8 @@ else:
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
-from papermill import display, read_notebook, read_notebooks, PapermillException
-from papermill.api import Notebook
+from .. import display, read_notebook, read_notebooks, PapermillException
+from ..api import Notebook
 from . import get_notebook_path, get_notebook_dir
 
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -8,9 +8,9 @@ import unittest
 
 import nbformat
 
-from papermill.api import read_notebook
-from papermill.execute import execute_notebook, log_outputs
-from papermill.exceptions import PapermillExecutionError
+from ..api import read_notebook
+from ..execute import execute_notebook, log_outputs
+from ..exceptions import PapermillExecutionError
 from . import get_notebook_path, RedirectOutput
 
 


### PR DESCRIPTION
Relative imports force everything to load locally and protects from accidental bad import patterns.