### PR TITLE
Added backslash escaping to prevent python parse errors on notebook execution with errant backslashes

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -250,7 +250,7 @@ def build_python_params(parameters):
     param_content = "# Parameters\n"
     for var, val in parameters.items():
         if isinstance(val, string_types):
-            val = '"%s"' % val.replace('"', '\\"')
+            val = '"%s"' % val.replace('\\', '\\\\').replace('"', r'\"')
         param_content += '%s = %s\n' % (var, val)
     return param_content
 
@@ -261,7 +261,7 @@ def build_r_params(parameters):
     param_content = "# Parameters\n"
     for var, val in parameters.items():
         if isinstance(val, string_types):
-            val = '"%s"' % val.replace('"', '\\"')
+            val = '"%s"' % val.replace('\\', '\\\\').replace('"', r'\"')
         elif val is True:
             val = 'TRUE'
         elif val is False:

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -45,6 +45,23 @@ class TestNotebookHelpers(unittest.TestCase):
         self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nmsg = "\\"Hello\\""\n')
         self.assertEqual(test_nb.parameters, {'msg': '"Hello"'})
 
+    def test_backslash_params(self):
+        execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'do\ not\ crash'})
+        test_nb = read_notebook(self.nb_test_executed_fname)
+        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "do\\\\ not\\\\ crash"\n')
+        self.assertEqual(test_nb.parameters, {'foo': 'do\\ not\\ crash'})
+
+    def test_backslash_quote_params(self):
+        execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'bar=\"baz\"'})
+        test_nb = read_notebook(self.nb_test_executed_fname)
+        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "bar=\\\\\\"baz\\\\\\""\n')
+        self.assertEqual(test_nb.parameters, {'foo': 'bar=\\\"baz\\\"'})
+
+    def test_double_backslash_quote_params(self):
+        execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'\\"bar\\"'})
+        test_nb = read_notebook(self.nb_test_executed_fname)
+        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "\\\\\\\\\\"bar\\\\\\\\\\""\n')
+        self.assertEqual(test_nb.parameters, {'foo': '\\\\\"bar\\\\\"'})
 
 class TestBrokenNotebook1(unittest.TestCase):
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -28,7 +28,7 @@ class TestNotebookHelpers(unittest.TestCase):
     def test_cell_insertion(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'msg': 'Hello'})
         test_nb = read_notebook(self.nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nmsg = "Hello"\n')
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', 'msg = "Hello"', ''])
         self.assertEqual(test_nb.parameters, {'msg': 'Hello'})
 
     def test_no_tags(self):
@@ -36,32 +36,32 @@ class TestNotebookHelpers(unittest.TestCase):
         nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
         execute_notebook(get_notebook_path(notebook_name), nb_test_executed_fname, {'msg': 'Hello'})
         test_nb = read_notebook(nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[0].get('source'), u'# Parameters\nmsg = "Hello"\n')
+        self.assertListEqual(test_nb.node.cells[0].get('source').split('\n'), ['# Parameters', 'msg = "Hello"', ''])
         self.assertEqual(test_nb.parameters, {'msg': 'Hello'})
 
     def test_quoted_params(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'msg': '"Hello"'})
         test_nb = read_notebook(self.nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nmsg = "\\"Hello\\""\n')
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', r'msg = "\"Hello\""', ''])
         self.assertEqual(test_nb.parameters, {'msg': '"Hello"'})
 
     def test_backslash_params(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'do\ not\ crash'})
         test_nb = read_notebook(self.nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "do\\\\ not\\\\ crash"\n')
-        self.assertEqual(test_nb.parameters, {'foo': 'do\\ not\\ crash'})
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', r'foo = "do\\ not\\ crash"', ''])
+        self.assertEqual(test_nb.parameters, {'foo': r'do\ not\ crash'})
 
     def test_backslash_quote_params(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'bar=\"baz\"'})
         test_nb = read_notebook(self.nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "bar=\\\\\\"baz\\\\\\""\n')
-        self.assertEqual(test_nb.parameters, {'foo': 'bar=\\\"baz\\\"'})
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', r'foo = "bar=\\\"baz\\\""', ''])
+        self.assertEqual(test_nb.parameters, {'foo': r'bar=\"baz\"'})
 
     def test_double_backslash_quote_params(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'foo': r'\\"bar\\"'})
         test_nb = read_notebook(self.nb_test_executed_fname)
-        self.assertEqual(test_nb.node.cells[1].get('source'), u'# Parameters\nfoo = "\\\\\\\\\\"bar\\\\\\\\\\""\n')
-        self.assertEqual(test_nb.parameters, {'foo': '\\\\\"bar\\\\\"'})
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', r'foo = "\\\\\"bar\\\\\""', ''])
+        self.assertEqual(test_nb.parameters, {'foo': r'\\"bar\\"'})
 
 class TestBrokenNotebook1(unittest.TestCase):
 


### PR DESCRIPTION
The large number of backslashes are to escape the escaped strings within the test definitions. Tested each locally that print(foo) displays the correct number of `\` characters for these tests.