### PR TITLE
[MRG] Add tagging mechanism for default parameters cell

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -193,16 +193,14 @@ def _parameterize_notebook(nb, kernel_name, parameters):
     kernel_name = kernel_name or nb.metadata.kernelspec.name
     param_content = _build_parameter_code(kernel_name, parameters)
 
-    # create a new cell with the passed in parameters, insert it after the
-    # existing cell tagged as "parameters"
-    newcell = nbformat.v4.new_code_cell(source=param_content)
-
     param_cell_index = _find_parameters_index(nb)
     if param_cell_index >= 0:
         old_parameters = nb.cells[param_cell_index]
-        newcell.metadata['tags'] = list(old_parameters.metadata['tags'])
         old_parameters.metadata['tags'].remove('parameters')
         old_parameters.metadata['tags'].append('default parameters')
+
+    newcell = nbformat.v4.new_code_cell(source=param_content)
+    newcell.metadata['tags'] = ['parameters']
 
     before = nb.cells[:param_cell_index + 1]
     after = nb.cells[param_cell_index + 1:]

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -193,17 +193,19 @@ def _parameterize_notebook(nb, kernel_name, parameters):
     kernel_name = kernel_name or nb.metadata.kernelspec.name
     param_content = _build_parameter_code(kernel_name, parameters)
 
-    # Remove the old cell and replace it with a new one containing parameter content.
+    # create a new cell with the passed in parameters, insert it after the
+    # existing cell tagged as "parameters"
+    newcell = nbformat.v4.new_code_cell(source=param_content)
+
     param_cell_index = _find_parameters_index(nb)
     if param_cell_index >= 0:
         old_parameters = nb.cells[param_cell_index]
-    else:
-        old_parameters = nbformat.v4.new_code_cell() # Fake cell
-        old_parameters.metadata['tags'] = ['parameters']
+        newcell.metadata['tags'] = list(old_parameters.metadata['tags'])
+        old_parameters.metadata['tags'].remove('parameters')
+        old_parameters.metadata['tags'].append('default parameters')
+
     before = nb.cells[:param_cell_index + 1]
     after = nb.cells[param_cell_index + 1:]
-    newcell = nbformat.v4.new_code_cell(source=param_content)
-    newcell.metadata['tags'] = old_parameters.metadata.pop('tags', [])
     nb.cells = before + [newcell] + after
 
 
@@ -226,7 +228,7 @@ def _find_parameters_index(nb):
     if not parameters_indices:
         return -1
     elif len(parameters_indices) > 1:
-        raise PapermillException("Multiple parameters tags found")
+        raise PapermillException("Multiple cells with parameters tag found")
     return parameters_indices[0]
 
 def _form_escaped_value(str_val):

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -1,17 +1,20 @@
+import sys
 import unittest
 
 from ..api import read_notebook
 from ..execute import _parameterize_notebook
 from . import get_notebook_path
 
+PYTHON = 'python2' if sys.version_info[0] == 2 else 'python3'
 
-class TestNotebookHelpers(unittest.TestCase):
+
+class TestNotebookParametrizing(unittest.TestCase):
     def test_preserving_tags(self):
         # test that other tags on the parameter cell are preserved
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
         test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
-        _parameterize_notebook(test_nb.node, 'python3', {'msg': 'Hello'})
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
 
         cell_zero = test_nb.node.cells[0]
         self.assertTrue('some tag' in cell_zero.get('metadata').get('tags'))
@@ -22,9 +25,20 @@ class TestNotebookHelpers(unittest.TestCase):
 
     def test_default_parameters_tag(self):
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+
+        cell_zero = test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+
+    def test_no_parameters(self):
+        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
         test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
-        _parameterize_notebook(test_nb.node, 'python3', {'msg': 'Hello'})
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
 
         cell_zero = test_nb.node.cells[0]
         self.assertTrue('default parameters'

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -9,8 +9,8 @@ PYTHON = 'python2' if sys.version_info[0] == 2 else 'python3'
 
 
 class TestNotebookParametrizing(unittest.TestCase):
-    def test_preserving_tags(self):
-        # test that other tags on the parameter cell are preserved
+    def test_not_preserving_tags(self):
+        # test that other tags on the parameter cell are _not_ preserved
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
         test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
@@ -20,7 +20,7 @@ class TestNotebookParametrizing(unittest.TestCase):
         self.assertTrue('some tag' in cell_zero.get('metadata').get('tags'))
 
         cell_one = test_nb.node.cells[1]
-        self.assertTrue('some tag' in cell_one.get('metadata').get('tags'))
+        self.assertTrue('some tag' not in cell_one.get('metadata').get('tags'))
         self.assertTrue('parameters' in cell_one.get('metadata').get('tags'))
 
     def test_default_parameters_tag(self):

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -1,0 +1,33 @@
+import unittest
+
+from ..api import read_notebook
+from ..execute import _parameterize_notebook
+from . import get_notebook_path
+
+
+class TestNotebookHelpers(unittest.TestCase):
+    def test_preserving_tags(self):
+        # test that other tags on the parameter cell are preserved
+        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+        test_nb.node.cells[0]['metadata']['tags'].append('some tag')
+
+        _parameterize_notebook(test_nb.node, 'python3', {'msg': 'Hello'})
+
+        cell_zero = test_nb.node.cells[0]
+        self.assertTrue('some tag' in cell_zero.get('metadata').get('tags'))
+
+        cell_one = test_nb.node.cells[1]
+        self.assertTrue('some tag' in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters' in cell_one.get('metadata').get('tags'))
+
+    def test_default_parameters_tag(self):
+        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+        test_nb.node.cells[0]['metadata']['tags'].append('some tag')
+
+        _parameterize_notebook(test_nb.node, 'python3', {'msg': 'Hello'})
+
+        cell_zero = test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_zero.get('metadata').get('tags'))


### PR DESCRIPTION
Fixes #84

The cell containing the default parameters of a notebook is now tagged
with "default parameters".

* [x] test basic tagging behaviour
* [x] test existing tags other than "parameters" are kept

WDYT?