### PR TITLE
Added python type preservation in parameter passing

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -230,7 +230,7 @@ def _find_parameters_index(nb):
     return parameters_indices[0]
 
 def _translate_escaped_str(str_val):
-    '''Reusable by most interpreters'''
+    """Reusable by most interpreters"""
     if isinstance(str_val, string_types):
         str_val = str_val.encode('unicode_escape')
         if sys.version_info >= (3, 0):
@@ -239,7 +239,7 @@ def _translate_escaped_str(str_val):
     return '"{}"'.format(str_val)
 
 def _translate_to_str(val):
-    '''Reusable by most interpreters'''
+    """Reusable by most interpreters"""
     return '{}'.format(val)
 
 # Registry for functions that build parameter assignment code.

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -262,12 +262,13 @@ def _translate_type_python(val):
     """Translate each of the standard json/yaml types to appropiate objects in python."""
     if isinstance(val, string_types):
         return _translate_type_str_python(val)
+    # Needs to be before integer checks
+    elif isinstance(val, bool):
+        return _translate_type_bool_python(val)
     elif isinstance(val, integer_types):
         return _translate_type_int_python(val)
     elif isinstance(val, float):
         return _translate_type_float_python(val)
-    elif isinstance(val, bool):
-        return _translate_type_bool_python(val)
     elif isinstance(val, dict):
         return _translate_type_dict_python(val)
     elif isinstance(val, list):

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -278,7 +278,7 @@ def build_r_params(parameters):
     """Writes parameters assignment code for R kernels."""
     param_content = "# Parameters\n"
     for var, val in parameters.items():
-        val = _form_escaped_value(val)
+        val = _form_escaped_str(val)
         if val is True:
             val = 'TRUE'
         elif val is False:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -244,7 +244,7 @@ def _form_escaped_python_value(val):
     """Translate each of the standard json/yaml types to appropiate objects in python."""
     if isinstance(val, string_types):
         return _form_escaped_str(val)
-    elif isinstance(val, integer_types) or isinstance(val, bool):
+    elif isinstance(val, integer_types + (float, bool)):
         return '{}'.format(val)
     elif isinstance(val, dict):
         escaped = ', '.join(["{}: {}".format(_form_escaped_str(k), _form_escaped_python_value(v)) for k, v in val.items()])

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -41,6 +41,10 @@ class TestPythonEscapers(unittest.TestCase):
         self.assertEqual(_form_escaped_python_value(12345), '12345')
         self.assertEqual(_form_escaped_python_value(-54321), '-54321')
 
+    def test_escaped_python_float(self):
+        self.assertEqual(_form_escaped_python_value(1.2345), '1.2345')
+        self.assertEqual(_form_escaped_python_value(-5432.1), '-5432.1')
+
     def test_escaped_python_bool(self):
         self.assertEqual(_form_escaped_python_value(True), 'True')
         self.assertEqual(_form_escaped_python_value(False), 'False')

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -9,45 +9,33 @@ import unittest
 import nbformat
 
 from ..api import read_notebook
-from ..execute import execute_notebook, log_outputs, _form_escaped_python_value
+from ..execute import execute_notebook, log_outputs, _translate_type_python
 from ..exceptions import PapermillExecutionError
 from . import get_notebook_path, RedirectOutput
 
 python_2 = sys.version_info[0] == 2
 
-class TestPythonEscapers(unittest.TestCase):
-    def test_escaped_python_string(self):
-        self.assertEqual(_form_escaped_python_value("foo"), '"foo"')
-        self.assertEqual(_form_escaped_python_value('{"foo": "bar"}'), '"{\\"foo\\": \\"bar\\"}"')
-
-    def test_escaped_python_dict(self):
-        self.assertEqual(_form_escaped_python_value({"foo": "bar"}), '{"foo": "bar"}')
-        self.assertEqual(_form_escaped_python_value({"foo": '"bar"'}), '{"foo": "\\"bar\\""}')
-
-    def test_escaped_python_dict_nested(self):
-        self.assertEqual(_form_escaped_python_value({"foo": ["bar"]}), '{"foo": ["bar"]}')
-        self.assertEqual(_form_escaped_python_value({"foo": {"bar": "baz"}}), '{"foo": {"bar": "baz"}}')
-        self.assertEqual(_form_escaped_python_value({"foo": {"bar": '"baz"'}}), '{"foo": {"bar": "\\"baz\\""}}')
-
-    def test_escaped_python_list(self):
-        self.assertEqual(_form_escaped_python_value(["foo"]), '["foo"]')
-        self.assertEqual(_form_escaped_python_value(["foo", '"bar"']), '["foo", "\\"bar\\""]')
-
-    def test_escaped_python_list_nested(self):
-        self.assertEqual(_form_escaped_python_value([{"foo": "bar"}]), '[{"foo": "bar"}]')
-        self.assertEqual(_form_escaped_python_value([{"foo": '"bar"'}]), '[{"foo": "\\"bar\\""}]')
-
-    def test_escaped_python_int(self):
-        self.assertEqual(_form_escaped_python_value(12345), '12345')
-        self.assertEqual(_form_escaped_python_value(-54321), '-54321')
-
-    def test_escaped_python_float(self):
-        self.assertEqual(_form_escaped_python_value(1.2345), '1.2345')
-        self.assertEqual(_form_escaped_python_value(-5432.1), '-5432.1')
-
-    def test_escaped_python_bool(self):
-        self.assertEqual(_form_escaped_python_value(True), 'True')
-        self.assertEqual(_form_escaped_python_value(False), 'False')
+@pytest.mark.parametrize("test_input,expected", [
+    ("foo", '"foo"'),
+    ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
+    ({"foo": "bar"}, '{"foo": "bar"}'),
+    ({"foo": '"bar"'}, '{"foo": "\\"bar\\""}'),
+    ({"foo": ["bar"]}, '{"foo": ["bar"]}'),
+    ({"foo": {"bar": "baz"}}, '{"foo": {"bar": "baz"}}'),
+    ({"foo": {"bar": '"baz"'}}, '{"foo": {"bar": "\\"baz\\""}}'),
+    (["foo"], '["foo"]'),
+    (["foo", '"bar"'], '["foo", "\\"bar\\""]'),
+    ([{"foo": "bar"}], '[{"foo": "bar"}]'),
+    ([{"foo": '"bar"'}], '[{"foo": "\\"bar\\""}]'),
+    (12345, '12345'),
+    (-54321, '-54321'),
+    (1.2345, '1.2345'),
+    (-5432.1, '-5432.1'),
+    (True, 'True'),
+    (False, 'False')
+])
+def test_translate_type_python(test_input, expected):
+    assert _translate_type_python(test_input) == expected
 
 class TestNotebookHelpers(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Passing a json object will give you a dict in your Python notebook instead of a string. Same for lists, numbers, and booleans. This makes passing complex parameters very nice for consumption in the notebook.

Broken out from https://github.com/nteract/papermill/pull/88