### PR TITLE
Added r type preservation in parameter passing

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -230,7 +230,7 @@ def _find_parameters_index(nb):
     return parameters_indices[0]
 
 def _translate_escaped_str(str_val):
-    '''Reusable by most interpreters'''
+    """Reusable by most interpreters"""
     if isinstance(str_val, string_types):
         str_val = str_val.encode('unicode_escape')
         if sys.version_info >= (3, 0):
@@ -239,7 +239,7 @@ def _translate_escaped_str(str_val):
     return '"{}"'.format(str_val)
 
 def _translate_to_str(val):
-    '''Reusable by most interpreters'''
+    """Reusable by most interpreters"""
     return '{}'.format(val)
 
 # Registry for functions that build parameter assignment code.

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -243,7 +243,7 @@ def _form_escaped_r_value(val):
         return _form_escaped_str(val)
     elif isinstance(val, bool):
         return 'TRUE' if val else 'FALSE'
-    elif isinstance(val, integer_types):
+    elif isinstance(val, integer_types + (float,)):
         return '{}'.format(val)
     elif isinstance(val, dict):
         escaped = ', '.join(["{} = {}".format(_form_escaped_str(k), _form_escaped_r_value(v)) for k, v in val.items()])

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -264,6 +264,7 @@ def _translate_type_r(val):
     """Translate each of the standard json/yaml types to appropiate objects in R."""
     if isinstance(val, string_types):
         return _translate_type_str_r(val)
+    # Needs to be before integer checks
     elif isinstance(val, bool):
         return _translate_type_bool_r(val)
     elif isinstance(val, integer_types):

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -41,6 +41,10 @@ class TestREscapers(unittest.TestCase):
         self.assertEqual(_form_escaped_r_value(12345), '12345')
         self.assertEqual(_form_escaped_r_value(-54321), '-54321')
 
+    def test_escaped_r_float(self):
+        self.assertEqual(_form_escaped_r_value(1.2345), '1.2345')
+        self.assertEqual(_form_escaped_r_value(-5432.1), '-5432.1')
+
     def test_escaped_r_bool(self):
         self.assertEqual(_form_escaped_r_value(True), 'TRUE')
         self.assertEqual(_form_escaped_r_value(False), 'FALSE')


### PR DESCRIPTION
Passing a json object will give you a named list in your R notebook instead of a string. Same for lists, numbers, and booleans. This makes passing complex parameters very nice for consumption in the notebook.

Broken out from https://github.com/nteract/papermill/pull/88