### PR TITLE
string + string (not string + bytes)

### DIFF
--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -467,7 +467,7 @@ class S3(object):
 
                         if encoding and not raw:
                             try:
-                                decoded = (undecoded + s).decode(encoding)
+                                decoded = undecoded + s.decode(encoding)
                                 undecoded = ''
                                 yield decoded
                             except UnicodeDecodeError as ude:


### PR DESCRIPTION
In Python 3, the following:
`
decoded = (undecoded + s).decode(encoding)
`
will result in a TypeError: must be str, not bytes because s is of type bytes and undecoded is of type string.
The suggested PR will fix this issue.