### PR TITLE
Provides the ability to run in environment execution where multiproce…

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -13,7 +13,13 @@ from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
 from nbconvert.preprocessors.base import Preprocessor
 from six import string_types, integer_types
-from tqdm import tqdm
+# tqdm creates 2 globals lock which raise OSException if the execution
+# environment does not have shared memory for processes, e.g. AWS Lambda
+try:
+    from tqdm import tqdm
+    no_tqdm = False
+except OSError:
+    no_tqdm = True
 
 from .conf import settings
 from .exceptions import PapermillException, PapermillExecutionError
@@ -170,7 +176,7 @@ def execute_notebook(notebook,
     processor = ExecutePreprocessor(
         timeout=None,
         kernel_name=kernel_name or nb.metadata.kernelspec.name, )
-    processor.progress_bar = progress_bar
+    processor.progress_bar = progress_bar and not no_tqdm
     processor.log_output = log_output
 
     processor.preprocess(nb, {})


### PR DESCRIPTION
Importing the tdqm module (_tqdm.py creates 2 global locks) in environments where multiprocessing locks are not implemented raises an OSError. For instance, running papermill in an AWS Lambda will fail because the AWS Lamdba execution environment does not have /dev/shm (shared memory for processes) support.
This suggested PR checks whether tdqm can be imported or not and prevent the use of the progress bar if the module can't be imported.