### PR TITLE
ip_display with list arguments

### DIFF
--- a/papermill/api.py
+++ b/papermill/api.py
@@ -53,7 +53,8 @@ def record(name, value):
     """
     # IPython.display.display takes a tuple of objects as first parameter
     # `http://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display`
-    ip_display(data={RECORD_OUTPUT_TYPE: {name: value}}, raw=True)
+    data = {RECORD_OUTPUT_TYPE: {name: value}}
+    ip_display(data, raw=True)
 
 
 def display(name, obj):
@@ -70,7 +71,7 @@ def display(name, obj):
     """
     data, metadata = IPython.core.formatters.format_display_data(obj)
     metadata['papermill'] = dict(name=name)
-    ip_display(data=data, metadata=metadata, raw=True)
+    ip_display(data, metadata=metadata, raw=True)
 
 
 def read_notebook(path):
@@ -221,7 +222,7 @@ class Notebook(object):
             raise PapermillException(
                 "Output Name '%s' is not available in this notebook.")
         output = outputs[name]
-        ip_display(data=output.data, metadata=output.metadata, raw=True)
+        ip_display(output.data, metadata=output.metadata, raw=True)
 
 
 def _get_papermill_metadata(nb, name, default=None):


### PR DESCRIPTION
objects to be displayed with ip_display (IPython.display.display) are in argument list not keywords.
The suggested changes are to remove the keyword argument "data=" and pass the objects as first argument.
(note that the data= does not work on the latest ipython)