### PR TITLE
Display args fix

### DIFF
--- a/papermill/api.py
+++ b/papermill/api.py
@@ -53,7 +53,8 @@ def record(name, value):
     """
     # IPython.display.display takes a tuple of objects as first parameter
     # `http://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display`
-    ip_display(data={RECORD_OUTPUT_TYPE: {name: value}}, raw=True)
+    data = {RECORD_OUTPUT_TYPE: {name: value}}
+    ip_display(data, raw=True)
 
 
 def display(name, obj):
@@ -70,7 +71,7 @@ def display(name, obj):
     """
     data, metadata = IPython.core.formatters.format_display_data(obj)
     metadata['papermill'] = dict(name=name)
-    ip_display(data=data, metadata=metadata, raw=True)
+    ip_display(data, metadata=metadata, raw=True)
 
 
 def read_notebook(path):
@@ -221,7 +222,7 @@ class Notebook(object):
             raise PapermillException(
                 "Output Name '%s' is not available in this notebook.")
         output = outputs[name]
-        ip_display(data=output.data, metadata=output.metadata, raw=True)
+        ip_display(output.data, metadata=output.metadata, raw=True)
 
 
 def _get_papermill_metadata(nb, name, default=None):

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -90,11 +90,11 @@ def test_display(format_display_data_mock, ip_display_mock):
     display('display_name', {'display_obj': 'hello'})
 
     format_display_data_mock.assert_called_once_with({'display_obj': 'hello'})
-    ip_display_mock.assert_called_once_with(data={'foo': 'bar'}, metadata={'metadata': 'baz', 'papermill': {'name': 'display_name'}}, raw=True)
+    ip_display_mock.assert_called_once_with({'foo': 'bar'}, metadata={'metadata': 'baz', 'papermill': {'name': 'display_name'}}, raw=True)
 
 
 
 @patch('papermill.api.ip_display')
 def test_record(ip_display_mock):
     record('a', 3)
-    ip_display_mock.assert_called_once_with(data={'application/papermill.record+json': {'a': 3}}, raw=True)
+    ip_display_mock.assert_called_once_with({'application/papermill.record+json': {'a': 3}}, raw=True)


### PR DESCRIPTION
objects to be displayed with ip_display (IPython.display.display) are in argument list not keywords.
data= does not work on the latest ipython

Spec fix included from original PR: https://github.com/nteract/papermill/pull/112