### PR TITLE
switch to html output error message

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -388,7 +388,15 @@ def raise_for_execution_errors(nb, output_path):
     if error:
         # Write notebook back out with the Error Message at the top of the Notebook.
         error_msg = ERROR_MESSAGE_TEMPLATE % str(error.exec_count)
-        error_msg_cell = nbformat.v4.new_markdown_cell(source=error_msg)
+        error_msg_cell = nbformat.v4.new_code_cell(
+            source="%%html\n" + ERROR_MESSAGE_TEMPLATE,
+            outputs=[
+                nbformat.v4.new_output(
+                    output_type="display_data",
+                    data={"text/html": ERROR_MESSAGE_TEMPLATE})
+            ],
+            metadata={"inputHidden": True,
+                      "hide_input": True})
         nb.cells = [error_msg_cell] + nb.cells
         write_ipynb(nb, output_path)
         raise error

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -147,7 +147,8 @@ class TestBrokenNotebook1(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = read_notebook(result_path)
-        self.assertEqual(nb.node.cells[0].cell_type, "markdown")
+        self.assertEqual(nb.node.cells[0].cell_type, "code")
+        self.assertEqual(nb.node.cells[0].outputs[0].output_type, "display_data")
         self.assertEqual(nb.node.cells[1].execution_count, 1)
         self.assertEqual(nb.node.cells[2].execution_count, 2)
         self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'error')
@@ -168,7 +169,8 @@ class TestBrokenNotebook2(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = read_notebook(result_path)
-        self.assertEqual(nb.node.cells[0].cell_type, "markdown")
+        self.assertEqual(nb.node.cells[0].cell_type, "code")
+        self.assertEqual(nb.node.cells[0].outputs[0].output_type, "display_data")
         self.assertEqual(nb.node.cells[1].execution_count, 1)
         self.assertEqual(nb.node.cells[2].execution_count, 2)
         self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'display_data')


### PR DESCRIPTION
In locked down environments, markdown no longer runs html inline. This switches the error message cell from markdown to HTML. Additionally, the code is hidden so it appears just as HTML output.