### PR TITLE
Set click disable_unicode_literals_warning=True

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 import base64
 
 import click
+click.disable_unicode_literals_warning = True
+
 import yaml
 
 from .execute import execute_notebook


### PR DESCRIPTION
Set click `disable_unicode_literals_warning=True` to disable unicode literals warning.

As Click (docs)[http://click.pocoo.org/5/python3/#unicode-literals] mentions, in order to continue using `unicode_literals` and ignore the warnings about it, `disable_unicode_literals_warning` must be set to `True`.