### PR TITLE
Made PapermillIO preserve handler ordering

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -50,7 +50,7 @@ class PapermillIO(object):
 
         if local_handler is None:
             raise PapermillException(
-                "Could not hand a registered schema handler for: {}"
+                "Could not find a registered schema handler for: {}"
                 .format(path))
 
         return local_handler


### PR DESCRIPTION
When handlers schemas overlapped in pattern matching the handler picking was non-deterministic. This preserves handler ordering and allows for existing handlers to be removed.

Also changed the class to no longer carry global state about handlers on the class.