### PR TITLE
Added repeat processing of notebooks to papermill

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,10 @@ for the parameters passed in at execution time. It acheive this by inserting a
 cell after the tagged cell. If no cell is tagged with ``parameters`` a cell will
 be inserted to the front of the notebook.
 
+Additionally, you can rerun notebooks through papermill and it will reuse the
+parameter cell it injected in the prior run. When a papermill generated notebook
+executes it will instead replace the ``parameters`` tagged cell.
+
 .. image:: docs/img/parameters.png
 
 Executing a Notebook

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -189,7 +189,6 @@ def execute_notebook(notebook,
     # always return notebook object
     return nb
 
-
 def _parameterize_notebook(nb, kernel_name, parameters):
     """Assigned parameters into the appropiate place in the input notebook
     Args:
@@ -204,22 +203,29 @@ def _parameterize_notebook(nb, kernel_name, parameters):
     # Generate parameter content based on the kernal_name
     kernel_name = kernel_name or nb.metadata.kernelspec.name
     param_content = _build_parameter_code(kernel_name, parameters)
-
     param_cell_index = _find_parameters_index(nb)
-    if param_cell_index >= 0:
-        old_parameters = nb.cells[param_cell_index]
-        old_parameters.metadata['tags'].remove('parameters')
-        old_parameters.metadata['tags'].append('default parameters')
+    param_cell = _get_cell(nb, param_cell_index)
+    meta_param_cell_index = nb.metadata.papermill.get('parameter_cell', param_cell_index)
 
-    newcell = nbformat.v4.new_code_cell(source=param_content)
-    newcell.metadata['tags'] = ['parameters']
+    # Check if we have a prior run's data to override
+    if 'parameters' in nb.metadata.papermill and \
+            param_cell_index == meta_param_cell_index and \
+            param_cell:
+        # Drop the old param cell as it's a prior run's injection
+        before = nb.cells[:param_cell_index]
+        after = nb.cells[param_cell_index + 1:]
+    else:
+        _prepare_default_parameter_cell(param_cell)
+        # Preserve the retagged parameter cell as a default parameter cell
+        before = nb.cells[:param_cell_index + 1]
+        after = nb.cells[param_cell_index + 1:]
 
-    before = nb.cells[:param_cell_index + 1]
-    after = nb.cells[param_cell_index + 1:]
-    nb.cells = before + [newcell] + after
+    new_cell = _build_cell(param_content, ['parameters'])
+    # Inject the new param cell
+    nb.cells = before + [new_cell] + after
 
     nb.metadata.papermill['parameters'] = parameters
-
+    nb.metadata.papermill['parameter_cell'] = len(before)
 
 def _execute_parameterized_notebook(nb,
                                     kernel_name=None,
@@ -249,8 +255,25 @@ def _execute_parameterized_notebook(nb,
     nb.metadata.papermill['end_time'] = t1.isoformat()
     nb.metadata.papermill['duration'] = (t1 - t0).total_seconds()
     nb.metadata.papermill['exception'] = any(
-        [cell.metadata.papermill.get('exception') for cell in nb.cells])
+        [cell.metadata.get('papermill', {}).get('exception') for cell in nb.cells])
 
+def _get_cell(nb, cell_index):
+    # Bounded index check
+    if cell_index >= 0 and cell_index < len(nb.cells):
+        return nb.cells[cell_index]
+    else:
+        return None
+
+def _prepare_default_parameter_cell(param_cell):
+    # Check if we have a parameter cell to move to default params
+    if param_cell:
+        param_cell.metadata['tags'].remove('parameters')
+        param_cell.metadata['tags'].append('default parameters')
+
+def _build_cell(contents, tags):
+    new_cell = nbformat.v4.new_code_cell(source=contents)
+    new_cell.metadata['tags'] = ['parameters']
+    return new_cell
 
 def _build_parameter_code(kernel_name, parameters):
     kernelspec = get_kernel_spec(kernel_name)
@@ -262,16 +285,15 @@ def _build_parameter_code(kernel_name, parameters):
         "No parameter builder functions specified for kernel '%s' or language '%s'"
         % (kernel_name, kernelspec.language))
 
-
 def _find_parameters_index(nb):
     parameters_indices = []
     for idx, cell in enumerate(nb.cells):
-        if "parameters" in cell.metadata.tags:
+        if 'parameters' in cell.metadata.tags:
             parameters_indices.append(idx)
     if not parameters_indices:
         return -1
     elif len(parameters_indices) > 1:
-        raise PapermillException("Multiple cells with parameters tag found")
+        raise PapermillException("Multiple cells with parmeters tag found")
     return parameters_indices[0]
 
 def _translate_escaped_str(str_val):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -154,18 +154,14 @@ def load_notebook_node(notebook_path):
 
     if not hasattr(nb.metadata, 'papermill'):
         nb.metadata['papermill'] = {
-            'parameters': dict(),
-            'environment_variables': dict(),
             'version': __version__
         }
 
     for cell in nb.cells:
         if not hasattr(cell.metadata, 'tags'):
-            cell.metadata['tags'] = [
-            ]  # Create tags attr if one doesn't exist.
+            # Create tags attr if one doesn't exist.
+            cell.metadata['tags'] = []
 
-        if not hasattr(cell.metadata, 'papermill'):
-            cell.metadata['papermill'] = dict()
     return nb
 
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -108,6 +108,25 @@ class TestNotebookHelpers(unittest.TestCase):
         self.assertListEqual(test_nb.node.cells[0].get('source').split('\n'), ['# Parameters', 'msg = "Hello"', ''])
         self.assertEqual(test_nb.parameters, {'msg': 'Hello'})
 
+    def test_repeat_run(self):
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(self.notebook_name))
+        nb_test_executed_second_fname = os.path.join(self.test_dir, 'output_2_{}'.format(self.notebook_name))
+        execute_notebook(self.notebook_path, nb_test_executed_fname, {'msg': 'Hello'})
+        execute_notebook(nb_test_executed_fname, nb_test_executed_second_fname, {'msg': 'Hello 2'})
+        test_nb = read_notebook(nb_test_executed_second_fname)
+        self.assertListEqual(test_nb.node.cells[1].get('source').split('\n'), ['# Parameters', 'msg = "Hello 2"', ''])
+        self.assertEqual(test_nb.parameters, {'msg': 'Hello 2'})
+
+    def test_repeat_no_param_run(self):
+        notebook_name = 'no_parameters.ipynb'
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        nb_test_executed_second_fname = os.path.join(self.test_dir, 'output_2_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), nb_test_executed_fname, {'msg': 'Hello'})
+        execute_notebook(nb_test_executed_fname, nb_test_executed_second_fname, {'msg': 'Hello 2'})
+        test_nb = read_notebook(nb_test_executed_second_fname)
+        self.assertListEqual(test_nb.node.cells[0].get('source').split('\n'), ['# Parameters', 'msg = "Hello 2"', ''])
+        self.assertEqual(test_nb.parameters, {'msg': 'Hello 2'})
+
     def test_quoted_params(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'msg': '"Hello"'})
         test_nb = read_notebook(self.nb_test_executed_fname)

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -4,45 +4,155 @@ import six
 
 from ..api import read_notebook
 from ..execute import _parameterize_notebook
+from ..exceptions import PapermillException
 from . import get_notebook_path
 
 PYTHON = 'python2' if six.PY2 else 'python3'
 
 
 class TestNotebookParametrizing(unittest.TestCase):
+    def setUp(self):
+        self.test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+
     def test_not_preserving_tags(self):
         # test that other tags on the parameter cell are _not_ preserved
-        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
-        test_nb.node.cells[0]['metadata']['tags'].append('some tag')
+        self.test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
-        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
 
-        cell_zero = test_nb.node.cells[0]
+        cell_zero = self.test_nb.node.cells[0]
         self.assertTrue('some tag' in cell_zero.get('metadata').get('tags'))
 
-        cell_one = test_nb.node.cells[1]
+        cell_one = self.test_nb.node.cells[1]
         self.assertTrue('some tag' not in cell_one.get('metadata').get('tags'))
         self.assertTrue('parameters' in cell_one.get('metadata').get('tags'))
 
     def test_default_parameters_tag(self):
-        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
 
-        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
-
-        cell_zero = test_nb.node.cells[0]
+        cell_zero = self.test_nb.node.cells[0]
         self.assertTrue('default parameters'
                         in cell_zero.get('metadata').get('tags'))
         self.assertTrue('parameters'
                         not in cell_zero.get('metadata').get('tags'))
 
     def test_no_parameters(self):
-        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
-        test_nb.node.cells[0]['metadata']['tags'].append('some tag')
+        self.test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
-        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
 
-        cell_zero = test_nb.node.cells[0]
+        cell_zero = self.test_nb.node.cells[0]
         self.assertTrue('default parameters'
                         in cell_zero.get('metadata').get('tags'))
         self.assertTrue('parameters'
                         not in cell_zero.get('metadata').get('tags'))
+
+
+    def test_parameterize_repeated(self):
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello 2'})
+
+        self.assertEqual(
+            self.test_nb.node.metadata.papermill.parameters,
+            {'msg': 'Hello 2'})
+
+        cell_zero = self.test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+
+        cell_one = self.test_nb.node.cells[1]
+        self.assertTrue('default parameters'
+                        not in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        in cell_one.get('metadata').get('tags'))
+        self.assertEqual(
+            cell_one.get('source').split('\n'),
+            ['# Parameters', 'msg = "Hello 2"', ''])
+
+    def test_parameters_in_metadata_with_tag(self):
+        self.test_nb.node.metadata.papermill['parameters'] = {'msg': 'Hello -1'}
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
+
+        cell_zero = self.test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertEqual(
+            cell_zero.get('source').split('\n'),
+            ['# Parameters', 'msg = "Hello"', ''])
+
+        cell_one = self.test_nb.node.cells[1]
+        self.assertTrue('default parameters'
+                        not in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_one.get('metadata').get('tags'))
+
+    def test_parameters_metadata_with_param_cell(self):
+        self.test_nb.node.metadata.papermill['parameters'] = {'msg': 'Hello -1'}
+        self.test_nb.node.metadata.papermill['parameter_cell'] = 0
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
+
+        cell_zero = self.test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertEqual(
+            cell_zero.get('source').split('\n'),
+            ['# Parameters', 'msg = "Hello"', ''])
+
+        cell_one = self.test_nb.node.cells[1]
+        self.assertTrue('default parameters'
+                        not in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_one.get('metadata').get('tags'))
+
+    def test_parameters_metadata_with_param_cell_mismatch(self):
+        self.test_nb.node.metadata.papermill['parameters'] = {'msg': 'Hello -1'}
+        self.test_nb.node.metadata.papermill['parameter_cell'] = 1
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
+
+        cell_zero = self.test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+
+        cell_one = self.test_nb.node.cells[1]
+        self.assertTrue('default parameters'
+                        not in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        in cell_one.get('metadata').get('tags'))
+        self.assertEqual(
+            cell_one.get('source').split('\n'),
+            ['# Parameters', 'msg = "Hello"', ''])
+
+    def test_parameters_in_metadata_but_no_tag(self):
+        self.test_nb = read_notebook(get_notebook_path("no_parameters.ipynb"))
+        self.test_nb.node.metadata.papermill['parameters'] = {'msg': 'Hello -1'}
+        _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'})
+
+        cell_zero = self.test_nb.node.cells[0]
+        self.assertTrue('default parameters'
+                        not in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertEqual(
+            cell_zero.get('source').split('\n'),
+            ['# Parameters', 'msg = "Hello"', ''])
+
+        cell_one = self.test_nb.node.cells[1]
+        self.assertTrue('default parameters'
+                        not in cell_one.get('metadata').get('tags'))
+        self.assertTrue('parameters'
+                        not in cell_one.get('metadata').get('tags'))
+
+    def test_fails_with_duplicate_parameter_tags(self):
+        self.test_nb.node.cells[0]['metadata']['tags'].append('parameters')
+        self.test_nb.node.cells[1]['metadata']['tags'].append('parameters')
+
+        self.assertRaises(PapermillException,
+            lambda: _parameterize_notebook(self.test_nb.node, PYTHON, {'msg': 'Hello'}))


### PR DESCRIPTION
This is an attempt at adding the ability to repeatedly process notebooks without adding an indefinite number of `default parameter` tagged cells. The idea is that we record a parameter cell used in a prior run, then if we find that cell we choose to replace the cell instead of insert after it. You can see the execution patterns in the tests, but essentially these two pattern follow:

First run, parameter cell set:
execute(['params', None, None], prior_cell = None) => ['default params', 'parameters', None]
Second run, output parameter cell from prior run identified:
execute(['default params', 'parameters', None], prior_cell = 1) => ['default params', 'parameters', None]

First run, no parameter cell set:
execute([None, None, None], prior_cell = None) => ['parameters', None, None]
Second run, output parameter cell from prior run identified:
execute(['parameters', None, None], prior_cell = 0) => ['parameters', None, None]

If a user moves the parameter tag such that it no longer lines up with the prior execution. We assume that the user has modified the notebook outside of papermill and we treat the run as normal execution. If we run an older notebook built by papermill, we default the parameter_cell field to the parameter cell provided we find other indicators of a papermill execution (`parameters` in metadata).

Open to suggested changes, this is indented to better support users who point papermill outputs back to inputs of new papermill executions. It's currently a little confusing when there's 5 `default parameters` cells.