### PR TITLE
Version fix with pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@ python:
   - 3.5
   - 3.6
 install:
-  - |
-    python2 -m pip install ipykernel --user "ipython<6"
-    python2 -m pip install ipykernel "ipython<6"
-    python2 -m ipykernel install --user
-    python -m pip install ipykernel "ipython<6"
-    python -m ipykernel install --user
-    pip install -e .
-    pip install -r requirements-dev.txt
+  - pip install setuptools pip --upgrade
+  - pip install -e .[test]
+  - python -m ipykernel install --user
 script:
-  - pytest -v --maxfail=2 --cov=papermill papermill/tests
+  # cd so we test the install, not the repo
+  - cd `mktemp -d`
+  - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
 after_success:
   - codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ boto3
 click
 future
 futures ; python_version < "3.0"
-ipython < 6.0 ; python_version < "3.0"
-ipython >= 6.0 ; python_version >= "3.0"
+ipython >= 5.0 
 pyyaml
 nbformat
 nbconvert

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ Note: Install ipython version based on python version.
       If python 2, install ipython 5.x (python2 is not supported in ipython 6.
 
 """
+from __future__ import print_function
 import os
 import sys
 from os.path import exists
@@ -27,6 +28,30 @@ test_required = [req.strip() for req in read(test_req_path).splitlines() if req.
 extras_require = {
     "test": test_required
 }
+
+pip_too_old = False
+pip_message = ''
+
+try:
+    import pip
+    pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
+    pip_too_old = pip_version < (9, 0, 1)
+    if pip_too_old :
+        # pip is too old to handle IPython deps gracefully
+        pip_message = 'Your pip version is out of date. Papermill requires pip >= 9.0.1. \n'\
+        'pip {} detected. Please install pip >= 9.0.1.'.format(pip.__version__)
+        print(error, file=sys.stderr)
+        sys.exit(1)
+except ImportError:
+        pip_message = 'No pip detected; we were unable to import pip. \n'\
+        'To use papermill, please install pip >= 9.0.1.'
+except Exception:
+    pass
+
+if pip_message:
+    print(pip_message, file=sys.stderr)
+    sys.exit(1)
+
 
 setup(name='papermill',
       version=versioneer.get_version(),

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ from setuptools import setup
 
 import versioneer
 
-ipython_req = 'ipython'
-
 python_2 = sys.version_info[0] == 2
 def read(fname):
     with open(fname, 'rU' if python_2 else 'r') as fhandle:


### PR DESCRIPTION
This modifies our `requirements.txt` to require `ipython>=5.0` without specifying a Python version. It also makes it such that when a user attempts to install papermill with pip <9.0.1, this will ask them to install pip >= 9.0.1, while explaining that this is a requirement of papermill.


This solution allows us to use IPython's solution for determining whether it should be version 5.x vs version 6+. 
**Note**:  IPython 7.0 will be Python 3.4+ compatible (dropping support for 3.3), and our current approach gets more complicated each time a new compatibility change is released. Instead, I suggest we rely on IPython to do the right thing for IPython.

Additionally, this solution allows us to have a more useful error message if someone is using too old a version of pip to install papermill. It still relies on `IPython`'s logic if someone uses `python setup.py develop`, meaning we do not need to implement secondary checks in our `__init__.py`.

This also makes it work as a universal wheel without requiring any of the checks inside `setup.py`.

To get more information on the way that IPython handles this (and why it handles it this way) you can watch this [talk](https://www.youtube.com/watch?v=2DkfPzWWC2Q) & or read these [slides](https://speakerdeck.com/pycon2017/py3-compatibility-in-a-user-friendly-manner). This ends up being a concrete implementation of the recommendations described in the [practicalities section of the python3 statement](https://python3statement.org/practicalities/).

@Carreau @MSeal @rgbkrk 