### PR TITLE
verify that the wheel can be installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
   - cd $TRAVIS_BUILD_DIR
   - python setup.py sdist bdist_wheel
-  - python -m pip install dist/papermill*.whl
-  - python -m pip install dist/papermill*.tar.gz
+  - python -m pip install --force-reinstall dist/papermill*.whl
+  - python -m pip install --force-reinstall --no-deps dist/papermill*.tar.gz
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ script:
   - cd `mktemp -d`
   - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
   - cd $TRAVIS_BUILD_DIR
-  - python setup.py bdist_wheel
+  - python setup.py sdist bdist_wheel
   - python -m pip install dist/papermill*.whl
+  - python -m pip install dist/papermill*.tar.gz
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ script:
   # cd so we test the install, not the repo
   - cd `mktemp -d`
   - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
+  - cd $TRAVIS_BUILD_DIR
+  - python setup.py bdist_wheel
+  - python -m pip install dist/papermill*.whl
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
   - cd $TRAVIS_BUILD_DIR
   - python setup.py sdist bdist_wheel
-  - python -m pip install --force-reinstall dist/papermill*.whl
-  - python -m pip install --force-reinstall --no-deps dist/papermill*.tar.gz
+  - python -m pip install -U --force-reinstall dist/papermill*.whl
+  - python -m pip install -U --force-reinstall --no-deps dist/papermill*.tar.gz
 after_success:
   - codecov


### PR DESCRIPTION
One quick integration test. It would be better to set up a virtualenv at the very end here (doing the right thing for Python2 vs Python3), this does at least verify that the `setup.py` runs in place within a distributed wheel.