### PR TITLE
Check manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ python:
 install:
   - pip install setuptools pip --upgrade
   - pip install -e .[test]
+  - pip install check-manifest
   - python -m ipykernel install --user
 script:
   # cd so we test the install, not the repo
+  - check-manifest
   - cd `mktemp -d`
   - pytest -v --maxfail=2 --cov=papermill --pyargs papermill
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
 recursive-include papermill *.py
+recursive-include papermill *.ipynb
+recursive-include papermill *.json
+recursive-include papermill *.yaml
+recursive-include papermill *.keep
 
 include setup.py
 include requirements.txt
@@ -6,6 +10,16 @@ include requirements-dev.txt
 include README.rst
 include LICENSE
 include MANIFEST.in
+include RELEASING.md
 
 include versioneer.py
 include papermill/_version.py
+include .coveragerc
+
+# Documentation
+graft docs
+# exclude build files
+prune docs/_build
+
+# Scripts
+graft scripts


### PR DESCRIPTION
In order to avoid manifest errors like those making 0.13.2 and 0.13.3 uninstallable via sdist, we should be making our sdists mirror our vcs. `check-manifest` does this for us. 

The MANIFEST.in changes were based on what it would complain about. 

Note: the `.keep` inclusion is necessary so that git sees the directory and is the convention we should follow elsewhere in the package for consistency. 