### PR TITLE
Display inferred params with `papermill foo.ipynb --help`

### DIFF
--- a/papermill/api.py
+++ b/papermill/api.py
@@ -15,6 +15,7 @@ from six import string_types
 
 from .exceptions import PapermillException
 from .iorw import load_notebook_node, list_notebook_files
+from .inspection import guess_parameters
 
 RECORD_OUTPUT_TYPE = 'application/papermill.record+json'
 DISPLAY_OUTPUT_TYPE = 'application/papermill.display+json'
@@ -223,6 +224,9 @@ class Notebook(object):
                 "Output Name '%s' is not available in this notebook.")
         output = outputs[name]
         ip_display(output.data, metadata=output.metadata, raw=True)
+
+    def guess_parameters(self):
+        return guess_parameters(self.node)
 
 
 def _get_papermill_metadata(nb, name, default=None):

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -9,35 +9,89 @@ click.disable_unicode_literals_warning = True
 
 import yaml
 
+from functools import wraps
 from .execute import execute_notebook
 from .iorw import read_yaml_file
 
+def add_options(options):
+    def _add_options(func):
+        for option in reversed(options):
+            func = option(func)
+        return func
+    return _add_options
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
+_options = [
+    click.option('--parameters', '-p', nargs=2, multiple=True,
+                  help='Parameters to pass to the parameters cell.'),
+    click.option('--parameters_raw', '-r', nargs=2, multiple=True,
+                  help='Parameters to be read as raw string.'),
+    click.option('--parameters_file', '-f', multiple=True,
+                  help='Path to YAML file containing parameters.'),
+    click.option('--parameters_yaml', '-y', multiple=True,
+                  help='YAML string to be used as parameters.'),
+    click.option('--parameters_base64', '-b', multiple=True,
+                  help='Base64 encoded YAML string as parameters.'),
+    click.option('--prepare-only/--prepare-execute', default=False,
+                  help="Flag for outputting the notebook without execution, "
+                       "but with parameters applied."),
+    click.option('--kernel', '-k', help='Name of kernel to run.'),
+    click.option('--progress-bar/--no-progress-bar', default=True,
+                  help="Flag for turning on the progress bar."),
+    click.option('--log-output/--no-log-output', default=False,
+                  help="Flag for writing notebook output to stderr."),
+    click.option('--start_timeout', type=int, default=60,
+                  help="Time in seconds to wait for kernel to start."),
+    click.option('--report-mode/--not-report-mode', default=False,
+                  help="Flag for hiding input."),
+]
+
+@click.command()
+@click.argument('notebook_path')
+@click.option('--help/--no-help', '-h', default=True)
+@add_options(_options)
+def notebook_help(notebook_path, help, **kwarg):
+    '''
+    We make a separate function here with --help available to enable
+    the same automatic error messaging, but with the ability to hijack
+    the normal help messaging for when a user types `--help` on an
+    input notebook
+    '''
+    # TODO add inspection function here!
+    click.echo("notebook_path: {}".format(notebook_path))
+
+class NotebookCommand(click.Command):
+    @property
+    def arguments(self):
+        for param in self.params:
+            if isinstance(param, click.core.Argument):
+                yield param
+
+    def arg_count(self):
+        return len(list(arg for arg in self.arguments))
+
+    def maybe_input_help(self):
+        # We want the normal help message if we don't have --help (arg 2)
+        return self.arg_count() == 2
+
+    def get_help(self, ctx):
+        """Formats the help into a string and returns it.  This creates a
+        formatter and will call into the following formatting methods:
+        """
+        if (self.maybe_input_help()):
+            return notebook_help()
+        return super(NotebookCommand, self).get_help(ctx)
+
+    def format_usage(self, ctx, formatter):
+        """Writes the usage line into the formatter."""
+        pieces = ['[OUTPUT_PATH/--help/-h]' if p == 'OUTPUT_PATH' else p
+                  for p in self.collect_usage_pieces(ctx)]
+        formatter.write_usage(ctx.command_path, ' '.join(pieces))
+
+@click.command(cls=NotebookCommand,
+               context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('notebook_path')
 @click.argument('output_path')
-@click.option('--parameters', '-p', nargs=2, multiple=True,
-              help='Parameters to pass to the parameters cell.')
-@click.option('--parameters_raw', '-r', nargs=2, multiple=True,
-              help='Parameters to be read as raw string.')
-@click.option('--parameters_file', '-f', multiple=True,
-              help='Path to YAML file containing parameters.')
-@click.option('--parameters_yaml', '-y', multiple=True,
-              help='YAML string to be used as parameters.')
-@click.option('--parameters_base64', '-b', multiple=True,
-              help='Base64 encoded YAML string as parameters.')
-@click.option('--prepare-only/--prepare-execute', default=False,
-              help="Flag for outputting the notebook without execution, "
-                   "but with parameters applied.")
-@click.option('--kernel', '-k', help='Name of kernel to run.')
-@click.option('--progress-bar/--no-progress-bar', default=True,
-              help="Flag for turning on the progress bar.")
-@click.option('--log-output/--no-log-output', default=False,
-              help="Flag for writing notebook output to stderr.")
-@click.option('--start_timeout', type=int, default=60,
-              help="Time in seconds to wait for kernel to start.")
-@click.option('--report-mode/--not-report-mode', default=False,
-              help="Flag for hiding input.")
+@add_options(_options)
 def papermill(notebook_path, output_path, parameters, parameters_raw,
               parameters_file, parameters_yaml, parameters_base64, prepare_only,
               kernel, progress_bar, log_output, start_timeout, report_mode):

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -12,6 +12,7 @@ import yaml
 from functools import wraps
 from .execute import execute_notebook
 from .iorw import read_yaml_file
+from .api import read_notebook
 
 def add_options(options):
     def _add_options(func):
@@ -56,10 +57,20 @@ def notebook_help(notebook_path, help, **kwarg):
     the normal help messaging for when a user types `--help` on an
     input notebook
     '''
-    # TODO add inspection function here!
+    params = read_notebook(notebook_path).guess_parameters()
     click.echo("notebook_path: {}".format(notebook_path))
+    if params:
+        click.echo("inferred parameters:")
+        for p in params:
+            click.echo("  {}: {} (default {})".format(p.name, p.inferred_type_name, p.default))
+    else:
+        click.echo("Can't infer anything about this notebook's parameters")
 
 class NotebookCommand(click.Command):
+    """
+    Adds an override to get_help to allow custom messages when one positional argument
+    has been provided.
+    """
     @property
     def arguments(self):
         for param in self.params:

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,0 +1,65 @@
+ # -*- coding: utf-8 -*-
+"""
+Deduce parameters of a notebook from the parameters cell.
+"""
+
+from __future__ import unicode_literals, print_function
+
+import ast
+from collections import namedtuple
+
+
+Parameter = namedtuple('Parameter', [
+    'name',
+    'inferred_type_name',  # string of type
+    'default',  # string representing the default value
+    'language',
+])
+
+
+def guess_parameters(node):
+    """Guess parameter types in a notebook."""
+    lang = node['metadata']['language_info']['name']
+    if lang in _parameter_inspectors:
+        return _parameter_inspectors[lang](node)
+    return node
+
+
+# Registry for functions that inspect parameters.
+_parameter_inspectors = {}
+
+
+def register_inspector(name):
+    """Decorator for registering functions that inspect parameters.
+
+    Wrapped functions should return a mapping of variable name to type name."""
+
+    def wrapper(func):
+        _parameter_inspectors[name] = func
+        return func
+
+    return wrapper
+
+
+# Python inspector
+@register_inspector('python')
+def guess_python_parameters(node):
+    params = []
+    for cell in node.cells:
+        if 'parameters' in cell.get('metadata', {}).get('tags', []):
+            src = cell['source']
+            for node in ast.parse(src).body:
+                if not isinstance(node, ast.Assign):
+                    continue
+                if not len(node.targets) == 1:
+                    continue
+                value = ast.literal_eval(node.value)
+                value_type = type(value)
+                type_name = None if value_type is type(None) else value_type.__name__
+                params.append(Parameter(
+                    name=node.targets[0].id,
+                    inferred_type_name=type_name,
+                    default=repr(ast.literal_eval(node.value)),
+                    language='python',
+                ))
+    return params

--- a/papermill/tests/test_api.py
+++ b/papermill/tests/test_api.py
@@ -15,6 +15,7 @@ from nbformat.v4 import (
 from .. import display, read_notebook, read_notebooks, PapermillException, record
 from ..api import Notebook, _get_notebook_outputs
 from . import get_notebook_path, get_notebook_dir
+from ..inspection import Parameter
 
 
 class TestNotebookClass(unittest.TestCase):
@@ -38,6 +39,11 @@ class TestNotebookClass(unittest.TestCase):
             columns=['name', 'value', 'type', 'filename']
         )
         assert_frame_equal(nb.dataframe, expected_df)
+        expected_inferred_parameters = [
+            Parameter('foo', 'int', '1', 'python'),
+            Parameter('bar', 'str', "'hello'", 'python'),
+        ]
+        self.assertEqual(nb.guess_parameters(), expected_inferred_parameters)
 
     def test_bad_file_ext(self):
 


### PR DESCRIPTION
Working on guessing param type from a parameters cell

plan: mirror the structure of `_build_parameter_code` for different languages