### PR TITLE
Changed parameter management to add an injected-parameters cell. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,9 @@ Usage
 Parametrizing a Notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To parametrize your notebook designate a cell with the tag ``parameters``.
-Papermill looks for the ``parameters`` cell and treat those values as defaults
-for the parameters passed in at execution time. It acheive this by inserting a
-cell after the tagged cell. If no cell is tagged with ``parameters`` a cell will
-be inserted to the front of the notebook.
+To parametrize your notebook designate a cell with the tag ``parameters``. Papermill looks for the ``parameters`` cell and treat those values as defaults for the parameters passed in at execution time. It acheive this by inserting a cell after the tagged cell. If no cell is tagged with ``parameters`` a cell will be inserted at the top of the notebook.
+
+Additionally, you can rerun notebooks through papermill and it will reuse the parameter cell it injected in the prior run. When a papermill generated notebook executes it will instead replace the ``injected-parameters`` tagged cell.
 
 .. image:: docs/img/parameters.png
 

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,11 @@ Usage
 Parametrizing a Notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To parametrize your notebook designate a cell with the tag ``parameters``. Papermill looks for the ``parameters`` cell and treat those values as defaults for the parameters passed in at execution time. It acheive this by inserting a cell after the tagged cell. If no cell is tagged with ``parameters`` a cell will be inserted at the top of the notebook.
+To parametrize your notebook designate a cell with the tag ``parameters``.
 
-Additionally, you can rerun notebooks through papermill and it will reuse the parameter cell it injected in the prior run. When a papermill generated notebook executes it will instead replace the ``injected-parameters`` tagged cell.
+Papermill looks for the ``parameters`` cell and treats this cell as defaults for the parameters passed in at execution time. Papermill will add a new cell tagged with ``injected-parameters`` with input parameters in order to overwrite the values in ``parameters``. If no cell is tagged with ``parameters`` the injected cell will be inserted at the top of the notebook.
+
+Additionally, if you rerun notebooks through papermill and it will reuse the ``injected-parameters`` cell from the prior run. In this case papermill will replace the old ``injected-parameters`` cell with the new run's inputs.
 
 .. image:: docs/img/parameters.png
 

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -10,8 +10,13 @@ PYTHON = 'python2' if six.PY2 else 'python3'
 
 
 class TestNotebookParametrizing(unittest.TestCase):
-    def test_not_preserving_tags(self):
-        # test that other tags on the parameter cell are _not_ preserved
+    def count_nb_injected_parameter_cells(self, nb):
+        return len([c for c in nb.node.cells
+            if 'injected-parameters' in c.get('metadata').get('tags', [])])
+
+
+    def test_no_tag_copying(self):
+        # Test that injected cell does not copy other tags
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
         test_nb.node.cells[0]['metadata']['tags'].append('some tag')
 
@@ -19,30 +24,60 @@ class TestNotebookParametrizing(unittest.TestCase):
 
         cell_zero = test_nb.node.cells[0]
         self.assertTrue('some tag' in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('parameters' in cell_zero.get('metadata').get('tags'))
 
         cell_one = test_nb.node.cells[1]
         self.assertTrue('some tag' not in cell_one.get('metadata').get('tags'))
-        self.assertTrue('parameters' in cell_one.get('metadata').get('tags'))
+        self.assertTrue('injected-parameters' in cell_one.get('metadata').get('tags'))
 
-    def test_default_parameters_tag(self):
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+    def test_injected_parameters_tag(self):
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
 
         _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
 
         cell_zero = test_nb.node.cells[0]
-        self.assertTrue('default parameters'
-                        in cell_zero.get('metadata').get('tags'))
         self.assertTrue('parameters'
+                        in cell_zero.get('metadata').get('tags'))
+        self.assertTrue('injected-parameters'
                         not in cell_zero.get('metadata').get('tags'))
 
-    def test_no_parameters(self):
+        cell_one = test_nb.node.cells[1]
+        self.assertTrue('injected-parameters'
+                        in cell_one.get('metadata').get('tags'))
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+    def test_repeated_run_injected_parameters_tag(self):
         test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
-        test_nb.node.cells[0]['metadata']['tags'].append('some tag')
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 0)
+
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+    def test_no_parameter_tag(self):
+        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+        test_nb.node.cells[0]['metadata']['tags'] = []
 
         _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
 
         cell_zero = test_nb.node.cells[0]
-        self.assertTrue('default parameters'
+        self.assertTrue('injected-parameters'
                         in cell_zero.get('metadata').get('tags'))
         self.assertTrue('parameters'
                         not in cell_zero.get('metadata').get('tags'))
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+    def test_repeated_run_no_parameters_tag(self):
+        test_nb = read_notebook(get_notebook_path("simple_execute.ipynb"))
+        test_nb.node.cells[0]['metadata']['tags'] = []
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 0)
+
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
+
+        _parameterize_notebook(test_nb.node, PYTHON, {'msg': 'Hello'})
+        self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)


### PR DESCRIPTION
Made execution reuse the injected-parameters cell for repeated calls to the same output notebook

Remake of https://github.com/nteract/papermill/pull/138/files