### PR TITLE
Stream outputs when logging

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -12,7 +12,7 @@ from six import string_types, integer_types
 
 from .conf import settings
 from .exceptions import PapermillException, PapermillExecutionError
-from .preprocess import PapermillExecutePreprocessor, no_tqdm
+from .preprocess import PapermillExecutePreprocessor
 from .iorw import load_notebook_node, write_ipynb, read_yaml_file, get_pretty_path
 
 
@@ -126,7 +126,7 @@ def _execute_parameterized_notebook(
         startup_timeout=start_timeout,
         kernel_name=kernel_name or nb.metadata.kernelspec.name,
     )
-    processor.progress_bar = progress_bar and not no_tqdm
+    processor.progress_bar = progress_bar
     processor.log_output = log_output
 
     processor.preprocess(nb, {})

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -12,7 +12,7 @@ from six import string_types, integer_types
 
 from .conf import settings
 from .exceptions import PapermillException, PapermillExecutionError
-from .preprocess import PapermillExecutePreprocessor, no_tqdm, log_outputs
+from .preprocess import PapermillExecutePreprocessor, no_tqdm
 from .iorw import load_notebook_node, write_ipynb, read_yaml_file, get_pretty_path
 
 

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -7,6 +7,7 @@ from concurrent import futures
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
 from nbformat.v4 import output_from_msg
+from traitlets import default
 
 from .iorw import write_ipynb
 
@@ -72,6 +73,14 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
 
     # TODO: Delete this wrapper when nbconvert allows for setting preprocessor
     # hood in a more convienent manner
+
+    @default("iopub_timeout")
+    def _default_iopub_timeout(self):
+        """The time to wait (in seconds) for IOPub output.
+        """
+        return 15
+        
+    
     def preprocess(self, nb, resources):
         """
         Copied with one edit of super -> papermill_preprocessor from nbconvert
@@ -225,9 +234,8 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
 
         while True:
             try:
-                # We've already waited for execute_reply, so all output
-                # should already be waiting. However, on slow networks, like
-                # in certain CI systems, waiting < 1 second might miss messages.
+                # We are not waiting for execute_reply, so all output
+                # will not be waiting for us. This may produce currently unknown issues.
                 # So long as the kernel sends a status:idle message when it
                 # finishes, we won't actually have to wait this long, anyway.
                 msg = self.kc.iopub_channel.get_msg(timeout=self.iopub_timeout)

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -49,12 +49,6 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
     # TODO: Delete this wrapper when nbconvert allows for setting preprocessor
     # hood in a more convienent manner
 
-    @default("iopub_timeout")
-    def _default_iopub_timeout(self):
-        """The time to wait (in seconds) for IOPub output.
-        """
-        return 15
-        
     
     def preprocess(self, nb, resources):
         """
@@ -210,9 +204,7 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
             try:
                 # We are not waiting for execute_reply, so all output
                 # will not be waiting for us. This may produce currently unknown issues.
-                # So long as the kernel sends a status:idle message when it
-                # finishes, we won't actually have to wait this long, anyway.
-                msg = self.kc.iopub_channel.get_msg(timeout=self.iopub_timeout)
+                msg = self.kc.iopub_channel.get_msg(timeout=None)
             except Empty:
                 self.log.warning("Timeout waiting for IOPub output")
                 if self.raise_on_iopub_timeout:

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -298,7 +298,7 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
             if (self.log_output 
                 and (out.output_type == "stream" 
                      or ("data" in out and "text/plain" in out.data))):
-                sys.stdout.write("Streamed output:\n")
+                sys.stdout.write("Streamed output (likely from Cell {}):\n".format(cell_index+1))
                 log_output(out)
             outs.append(out)
 

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -22,7 +22,16 @@ PENDING = "pending"
 RUNNING = "running"
 COMPLETED = "completed"
 
-
+def log_output(output):
+    if output.output_type == "stream":
+        if output.name == "stdout":
+            sys.stdout.write("".join(output.text) + "\n")
+        elif output.name == "stderr":
+            sys.stderr.write("".join(output.text) + "\n")
+    elif "data" in output and "text/plain" in output.data:
+        sys.stdout.write("".join(output.data['text/plain']) + "\n")
+        
+        
 def log_outputs(cell):
     execution_count = cell.get("execution_count")
     if not execution_count:

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -172,8 +172,9 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
         with futures.ThreadPoolExecutor(max_workers=1) as executor:
 
             # Generate the iterator
-            if self.progress_bar:
-                execution_iterator = tqdm(enumerate(nb.cells), total=len(nb.cells))
+            if self.progress_bar and not no_tqdm:
+                execution_iterator = tqdm(enumerate(nb.cells), total=len(nb.cells), 
+                                          bar_format="{l_bar}{bar}{r_bar}\n")
             else:
                 execution_iterator = enumerate(nb.cells)
 

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -39,31 +39,6 @@ def log_output(output):
         sys.stdout.write("".join(output.data['text/plain']) + "\n")
         
         
-def log_outputs(cell):
-    execution_count = cell.get("execution_count")
-    if not execution_count:
-        return
-
-    stderrs = []
-    stdouts = []
-    for output in cell.get("outputs", []):
-        if output.output_type == "stream":
-            if output.name == "stdout":
-                stdouts.append("".join(output.text))
-            elif output.name == "stderr":
-                stderrs.append("".join(output.text))
-        elif "data" in output and "text/plain" in output.data:
-            stdouts.append(output.data['text/plain'])
-
-    # Log stdouts
-    sys.stdout.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
-    sys.stdout.write("\n".join(stdouts) + "\n")
-
-    # Log stderrs
-    sys.stderr.write('{:-<40}'.format("Out [%s] " % execution_count) + "\n")
-    sys.stderr.write("\n".join(stderrs) + "\n")
-
-
 class PapermillExecutePreprocessor(ExecutePreprocessor):
     """Module containing a preprocessor that executes the code cells
     and updates outputs"""
@@ -212,8 +187,6 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
 
                     nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
                     cell.metadata['papermill']['exception'] = False
-                    if self.log_output:
-                        log_outputs(nb.cells[index])
 
                 except CellExecutionError:
                     cell.metadata['papermill']['exception'] = True

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -229,7 +229,9 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
                 else:
                     continue
             elif msg_type == 'execute_input':
-                sys.stdout.write('Executing Cell {:-<40}\n'.format(content.get("execution_count", "*")))
+                if self.log_output:
+                    sys.stdout.write(
+                        'Executing Cell {:-<40}\n'.format(content.get("execution_count", "*")))
                 continue
             elif msg_type == 'clear_output':
                 outs[:] = []
@@ -256,8 +258,6 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
                 self.log.error("unhandled iopub msg: " + msg_type)
                 continue
             if display_id:
-                # record output index in:
-                #   _display_id_map[display_id][cell_idx]
                 cell_map = self._display_id_map.setdefault(display_id, {})
                 output_idx_list = cell_map.setdefault(cell_index, [])
                 output_idx_list.append(len(outs))

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -32,9 +32,9 @@ COMPLETED = "completed"
 def log_output(output):
     if output.output_type == "stream":
         if output.name == "stdout":
-            sys.stdout.write("".join(output.text) + "\n")
+            sys.stdout.write("".join(output.text))
         elif output.name == "stderr":
-            sys.stderr.write("".join(output.text) + "\n")
+            sys.stderr.write("".join(output.text))
     elif "data" in output and "text/plain" in output.data:
         sys.stdout.write("".join(output.data['text/plain']) + "\n")
         
@@ -236,6 +236,7 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
                 else:
                     continue
             elif msg_type == 'execute_input':
+                sys.stdout.write('Executing Cell {:-<40}\n'.format(content.get("execution_count", "*")))
                 continue
             elif msg_type == 'clear_output':
                 outs[:] = []
@@ -268,13 +269,13 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
                 output_idx_list = cell_map.setdefault(cell_index, [])
                 output_idx_list.append(len(outs))
 
-            if (self.log_output 
-                and (out.output_type == "stream" 
-                     or ("data" in out and "text/plain" in out.data))):
-                sys.stdout.write("Streamed output (likely from Cell {}):\n".format(cell_index+1))
+            if self.log_output:
                 log_output(out)
             outs.append(out)
 
         exec_reply = self._wait_for_reply(msg_id, cell)
+        if self.log_output: 
+            sys.stdout.write('Ending Cell {:-<43}\n'.format(
+                exec_reply.get("content",{}).get("execution_count", content)))
 
         return exec_reply, outs

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -22,11 +22,11 @@ from ..api import read_notebook
 from .. import execute
 from ..execute import (
     execute_notebook,
-    log_outputs,
     _translate_type_python,
     _translate_type_r,
     _translate_type_scala,
 )
+from ..preprocess import log_output
 from ..exceptions import PapermillExecutionError
 from . import get_notebook_path, RedirectOutput
 
@@ -271,36 +271,38 @@ class TestLogging(unittest.TestCase):
 
         # stderr output
         with RedirectOutput() as redirect:
-            log_outputs(nb.cells[0])
+            for output in nb.cells[0].get("outputs", []):
+                log_output(output)
             stdout = redirect.get_stdout()
-            self.assertEqual(stdout, u'Out [1] --------------------------------\n\n')
+            self.assertEqual(stdout, u"")
             stderr = redirect.get_stderr()
             self.assertEqual(
-                stderr, u'Out [1] --------------------------------\nINFO:test:test text\n\n'
+                stderr, u"INFO:test:test text\n"
             )
 
         # stream output
         with RedirectOutput() as redirect:
-            log_outputs(nb.cells[1])
-            stdout = redirect.get_stdout()
-            self.assertEqual(stdout, u'Out [2] --------------------------------\nhello world\n\n')
+            for output in nb.cells[1].get("outputs", []):
+                log_output(output)
+            stdout = redirect.get_stdout() 
+            self.assertEqual(stdout, u'hello world\n')
             stderr = redirect.get_stderr()
-            self.assertEqual(stderr, u'Out [2] --------------------------------\n\n')
+            self.assertEqual(stderr, u'')
 
         # text/plain output
         with RedirectOutput() as redirect:
-            log_outputs(nb.cells[2])
+            for output in nb.cells[2].get("outputs", []):
+                log_output(output)
             stdout = redirect.get_stdout()
             self.assertEqual(
                 stdout,
                 (
-                    "Out [3] --------------------------------\n"
                     "<matplotlib.axes._subplots.AxesSubplot at 0x7f8391f10290>\n"
                     "<matplotlib.figure.Figure at 0x7f830af7b350>\n"
                 ),
             )
             stderr = redirect.get_stderr()
-            self.assertEqual(stderr, u'Out [3] --------------------------------\n\n')
+            self.assertEqual(stderr, u'')
 
 
 class TestNBConvertCalls(unittest.TestCase):


### PR DESCRIPTION
This changes the order in which we are processing messages when running individual cells. 

Importantly, we are no longer waiting for `execute_reply` which means we can no longer expect all iopub messages to be present when processing them.

While this is a useful simplifying assumption, it means we cannot stream the outputs as they come in (behaviour expected from other front-end notebook contexts).

To address this change in the expectations around the iopub messages, I increased the default iopub_timeout value. We may want to strengthen this and disable iopub timeout errors by default.

Because we don't know what the execution count is until we get the execute reply, we cannot canonically state what output number these cells will have, so we optimistically try to log the streamed messages.

The nbconvert execute preprocessor would benefit from further refactoring so that we did not have to recreate so much of the code… but as of right now that's not the case.