### PR TITLE
New Papermill Logo!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Papermill](https://user-images.githubusercontent.com/836375/27929844-6bb34e62-6249-11e7-9a2a-00849a64940c.png)](https://github.com/nteract/papermill)
+<a href="https://github.com/nteract/papermill"><img src="https://media.githubusercontent.com/media/nteract/logos/master/nteract_papermill/exports/images/png/papermill_logo_wide.png" height="48px" /></a>
 =======================================================================================================================================================================
 
 [![image](https://travis-ci.org/nteract/papermill.svg?branch=master)](https://travis-ci.org/nteract/papermill)


### PR DESCRIPTION
@fabric-8 put together a new papermill logo! This updates the README to use it. 😄 

![papermill wide logo](https://media.githubusercontent.com/media/nteract/logos/bcd24bb884fc5a31412c8c2d6ee1085f789566b3/nteract_papermill/exports/images/png/papermill_logo_wide.png)

see https://github.com/nteract/logos/pull/13