### PR TITLE
excludes versioneer from coverage reporting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,10 @@ parentdir_prefix = papermill-
 
 [coverage:run]
 branch = False
-omit = papermill/tests/*,papermill/_version.py
+omit =
+    papermill/tests/*
+    papermill/_version.py
+    versioneer.py
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
Closes #176, or maybe doesn't, if linting needs a touch up too. This only excludes versioneer from coverage, following the [omit docs for coverage](https://coverage.readthedocs.io/en/coverage-4.2/source.html#source).