### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - 3.5
   - 3.6
 matrix:
+  allow_failures:  # ModuleNotFoundError: No module named 'google_compute_engine'
+    - python: 3.7
   include:
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ python:
   - 2.7
   - 3.5
   - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   - pip install setuptools pip --upgrade
   - pip install -e .[test]

--- a/papermill/adl.py
+++ b/papermill/adl.py
@@ -1,6 +1,5 @@
-import os
-from azure.datalake.store import lib, core, multithread
 import re
+from azure.datalake.store import core, lib
 
 
 class ADL(object):

--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -697,7 +697,7 @@ class S3(object):
         objects: optional
             if True then this will return the actual boto objects for
             files or prefixes that are encountered
-        
+
         """
         assert self._is_s3(name), "name must be in form s3://bucket/prefix/"
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     install_requires=required,
     extras_require=extras_require,
     entry_points={'console_scripts': ['papermill = papermill.cli:papermill']},
-    project_urls= {
+    project_urls={
         'Documentation': 'https://papermill.readthedocs.io',
         'Funding': 'https://nteract.io',
         'Source': 'https://github.com/nteract/papermill/',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup.py
 Note: Do a version check for IPython.
     IPython v6+ no longer supports Python 2.
     If Python 2, intall ipython 5.x.
-    
+
 """
 from __future__ import print_function
 import os


### PR DESCRIPTION
#187 done in alignment with travis-ci/travis-ci#9069

Plus whitespace changes in other files to align with #183

On Python 3.7: ModuleNotFoundError: No module named 'google_compute_engine'
* GCE might not yet support Python 3.7...
* https://github.com/GoogleCloudPlatform/compute-image-packages/blob/master/setup.py#L66