### PR TITLE
requirements: bump version for nbconvert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ futures ; python_version < "3.0"
 ipython >= 5.0 
 pyyaml
 nbformat
-nbconvert
+nbconvert >= 5.3
 six
 tqdm
 jupyter_client


### PR DESCRIPTION
papermill depends on function "_wait_for_reply" which is only available in 5.3 and later, per https://github.com/jupyter/nbconvert/commit/9bd05ffbaefd6b45452cca51fd7ca8964e033c47

not sure if other functions require a newer version.