### PR TITLE
throw nice error if directory doesn't exist

### DIFF
--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -13,6 +13,10 @@ class FileExistsError(AwsError):
     """Raised when a File already exists on S3."""
 
 
+class FileNotFoundError(AwsError):
+    """Raised when a folder doesn't exist"""
+
+
 class PapermillException(Exception):
     """Raised when an exception is encountered when operating on a notebook."""
 

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -32,3 +32,6 @@ class PapermillExecutionError(PapermillException):
         message += "\n"
 
         super(PapermillExecutionError, self).__init__(message)
+
+class NoSuchDirectory(Exception):
+    """Raised when a folder doesn't exist"""

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -32,7 +32,3 @@ class PapermillExecutionError(PapermillException):
         message += "\n"
 
         super(PapermillExecutionError, self).__init__(message)
-
-
-class NoSuchDirectory(Exception):
-    """Raised when a folder doesn't exist"""

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -13,10 +13,6 @@ class FileExistsError(AwsError):
     """Raised when a File already exists on S3."""
 
 
-class FileNotFoundError(AwsError):
-    """Raised when a folder doesn't exist"""
-
-
 class PapermillException(Exception):
     """Raised when an exception is encountered when operating on a notebook."""
 

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -33,5 +33,6 @@ class PapermillExecutionError(PapermillException):
 
         super(PapermillExecutionError, self).__init__(message)
 
+
 class NoSuchDirectory(Exception):
     """Raised when a folder doesn't exist"""

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -88,12 +88,12 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
-        path = (path.split("/"))[:-1]
-        path = "/".join(path)
-        if not path.endswith("/"):
-            path += "/"
-        if not os.path.exists(path):
-            raise FileNotFoundError('output folder {} doesn\'t exist!'.format(path))
+        dir = (path.split("/"))[:-1]
+        dir = "/".join(dir)
+        if not dir.endswith("/"):
+            dir += "/"
+        if not os.path.exists(dir):
+            raise FileNotFoundError('output folder {} doesn\'t exist!'.format(dir))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -91,7 +91,7 @@ class LocalHandler(object):
         path = (path.split("/"))[:-1]
         path = "/".join(path)
         if not path.endswith("/"):
-            path +="/"
+            path += "/"
         if not os.path.exists(path):
             raise FileNotFoundError('output folder {} doesn\'t exist!'.format(path))
         with io.open(path, 'w', encoding="utf-8") as f:

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -11,7 +11,7 @@ import requests
 import yaml
 
 from . import __version__
-from .exceptions import PapermillException, FileNotFoundError
+from .exceptions import PapermillException
 from .s3 import S3
 from .adl import ADL
 
@@ -88,12 +88,11 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
-        dir = (path.split("/"))[:-1]
-        dir = "/".join(dir)
+        dir = os.path.dirname(path)
         if not dir.endswith("/"):
             dir += "/"
         if not os.path.exists(dir):
-            raise FileNotFoundError('output folder {} doesn\'t exist!'.format(dir))
+            raise Exception('output folder {} doesn\'t exist!'.format(dir))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -15,6 +15,11 @@ from .exceptions import PapermillException
 from .s3 import S3
 from .adl import ADL
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 class PapermillIO(object):
     def __init__(self):
@@ -99,7 +104,6 @@ class LocalHandler(object):
 
 
 class S3Handler(object):
-
     keyname = None
 
     @classmethod

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -11,7 +11,7 @@ import requests
 import yaml
 
 from . import __version__
-from .exceptions import PapermillException, NoSuchDirectory
+from .exceptions import PapermillException
 from .s3 import S3
 from .adl import ADL
 
@@ -88,11 +88,8 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
-        dir = os.path.dirname(path)
-        if not dir.endswith("/"):
-            dir += "/"
-        if not os.path.exists(dir):
-            raise NoSuchDirectory('output folder {} doesn\'t exist.'.format(dir))
+        if not os.path.exists(os.path.dirname(path)):
+            raise FileNotFoundError('output folder {} doesn\'t exist.'.format(os.path.dirname(path)))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -11,7 +11,7 @@ import requests
 import yaml
 
 from . import __version__
-from .exceptions import PapermillException
+from .exceptions import PapermillException, FileNotFoundError
 from .s3 import S3
 from .adl import ADL
 
@@ -88,6 +88,8 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
+        if not os.path.exists(path):
+            raise FileNotFoundError('output folder {} doesn\'t exist!'.format(path))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -88,6 +88,10 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
+        path = (path.split("/"))[:-1]
+        path = "/".join(path)
+        if not path.endswith("/"):
+            path +="/"
         if not os.path.exists(path):
             raise FileNotFoundError('output folder {} doesn\'t exist!'.format(path))
         with io.open(path, 'w', encoding="utf-8") as f:

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -11,7 +11,7 @@ import requests
 import yaml
 
 from . import __version__
-from .exceptions import PapermillException
+from .exceptions import PapermillException, NoSuchDirectory
 from .s3 import S3
 from .adl import ADL
 
@@ -92,7 +92,7 @@ class LocalHandler(object):
         if not dir.endswith("/"):
             dir += "/"
         if not os.path.exists(dir):
-            raise Exception('output folder {} doesn\'t exist!'.format(dir))
+            raise NoSuchDirectory('output folder {} doesn\'t exist.'.format(dir))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     from mock import Mock, patch
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 from ..exceptions import PapermillException
 from ..iorw import HttpHandler, LocalHandler, ADLHandler, PapermillIO
 

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -98,8 +98,8 @@ class TestLocalHandler(unittest.TestCase):
             self.assertEqual(f.read().strip(), u'✄')
 
     def test_write_no_directory_exists(self):
-        self.assertEqual(LocalHandler.write("buffer", "fake/path/fake/path/fakenb.ipynb"),
-                         "output folder fake/path doesn't exist.")
+        with self.assertRaises(FileNotFoundError):
+            LocalHandler.write("buffer", "fake/path/fake/path/fakenb.ipynb")
 
 
 class TestADLHandler(unittest.TestCase):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -98,7 +98,8 @@ class TestLocalHandler(unittest.TestCase):
             self.assertEqual(f.read().strip(), u'✄')
 
     def test_write_no_directory_exists(self):
-        self.assertEqual(LocalHandler.write("buffer", "fake/path/fakenb.ipynb"), "output folder fake/path doesn't exist.")
+        self.assertEqual(LocalHandler.write("buffer", "fake/path/fake/path/fakenb.ipynb"),
+                         "output folder fake/path doesn't exist.")
 
 
 class TestADLHandler(unittest.TestCase):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -97,6 +97,9 @@ class TestLocalHandler(unittest.TestCase):
         with io.open(path, 'r', encoding='utf-8') as f:
             self.assertEqual(f.read().strip(), u'✄')
 
+    def test_write_no_directory_exists(self):
+        self.assertEqual(LocalHandler.write("buffer", "fake/path/fakenb.ipynb"), "output folder fake/path doesn't exist.")
+
 
 class TestADLHandler(unittest.TestCase):
     """

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -99,7 +99,7 @@ class TestLocalHandler(unittest.TestCase):
 
     def test_write_no_directory_exists(self):
         with self.assertRaises(FileNotFoundError):
-            LocalHandler.write("buffer", "fake/path/fake/path/fakenb.ipynb")
+            LocalHandler.write("buffer", "fake/path/fakenb.ipynb")
 
 
 class TestADLHandler(unittest.TestCase):


### PR DESCRIPTION
@MSeal this addresses the issue of Nicer error when output directory doesn't exist #201
Please review the PR and let me know for any changes. At present I added the exception throwing for local file system. Please let me know if I need to do the same for others as well