### PR TITLE
Fixed local directory saves to not raise exceptions

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -107,8 +107,9 @@ class LocalHandler(object):
 
     @classmethod
     def write(cls, buf, path):
-        if not os.path.exists(os.path.dirname(path)):
-            raise FileNotFoundError('output folder {} doesn\'t exist.'.format(os.path.dirname(path)))
+        dirname = os.path.dirname(path)
+        if dirname and not os.path.exists(dirname):
+            raise FileNotFoundError("output folder {} doesn't exist.".format(dirname))
         with io.open(path, 'w', encoding="utf-8") as f:
             f.write(buf)
 

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -123,6 +123,11 @@ class TestLocalHandler(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             LocalHandler.write("buffer", "fake/path/fakenb.ipynb")
 
+    def test_write_local_directory(self):
+        with patch.object(io, 'open'):
+            # Shouldn't raise with missing directory
+            LocalHandler.write("buffer", "local.ipynb")
+
 
 class TestADLHandler(unittest.TestCase):
     """


### PR DESCRIPTION
Missed this case when reviewing a PR. Ran into it with testing engines.