### PR TITLE
Add note on using multiple AWS accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Amazon S3 account:
 $ papermill local/input.ipynb s3://bkt/output.ipynb -p alpha 0.6 -p l1_ratio 0.1
 ```
 
+**NOTE:**
+If you use multiple AWS accounts, and you have [properly configured your AWS  credentials](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html), then you can specify which account to use by setting the `AWS_PROFILE` environment variable at the command-line. For example:
+
+``` {.sourceCode .bash}
+$ AWS_PROFILE=dev_account papermill local/input.ipynb s3://bkt/output.ipynb -p alpha 0.6 -p l1_ratio 0.1
+```
+
 In the above example, two parameters are set: ``alpha`` and ``l1_ratio`` using ``-p`` (``--parameters`` also works). Parameter values that look like booleans or numbers will be interpreted as such. Here are the different ways users may set parameters:
 
 ``` {.sourceCode .bash}


### PR DESCRIPTION
- If you set AWS_PROFILE, you can specify which
  credentials to use for storing results to s3.

Addresses issue #233 