### PR TITLE
Fixed checks for ipython kernel to run before ipython might be imported by other functions

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -5,6 +5,11 @@ import dateutil
 
 from functools import wraps
 
+from .log import logger
+from .exceptions import PapermillException
+from .preprocess import PapermillExecutePreprocessor
+from .iorw import write_ipynb
+
 # tqdm creates 2 globals lock which raise OSException if the execution
 # environment does not have shared memory for processes, e.g. AWS Lambda
 try:
@@ -13,11 +18,7 @@ try:
     no_tqdm = False
 except OSError:
     no_tqdm = True
-
-from .log import logger
-from .exceptions import PapermillException
-from .preprocess import PapermillExecutePreprocessor
-from .iorw import write_ipynb
+using_ipykernel = 'ipykernel' in sys.modules
 
 
 class PapermillEngines(object):
@@ -99,7 +100,7 @@ class NotebookExecutionManager(object):
 
         This is called automatically when constructed.
         """
-        if 'ipykernel' in sys.modules:
+        if using_ipykernel:
             # Load the notebook version if we're being called from a notebook
             self.pbar = tqdm_notebook(total=len(self.nb.cells))
         else:

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -1,4 +1,3 @@
-import sys
 import abc
 import copy
 import dateutil
@@ -65,9 +64,9 @@ class TestNotebookExecutionManager(unittest.TestCase):
 
     def test_notebook_pbar(self):
         # Need this or the tqdm notebook status printer fails
-        with patch('ipywidgets.HBox'):
-            with patch('ipywidgets.IntProgress'):
-                with patch.dict(sys.modules, {'ipykernel': True}):
+        with patch.object(engines, 'using_ipykernel', return_value=True):
+            with patch('ipywidgets.HBox'):
+                with patch('ipywidgets.IntProgress'):
                     nb_man = NotebookExecutionManager(self.nb)
 
             self.assertEqual(nb_man.pbar.total, len(self.nb.cells))


### PR DESCRIPTION
Noticed the import value changed after using nbformat function which rely on ipython. This fixes the issue by preloading the check.