### PR TITLE
stick an s in install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup.py
 
 Note: Do a version check for IPython.
     IPython v6+ no longer supports Python 2.
-    If Python 2, intall ipython 5.x.
+    If Python 2, install ipython 5.x.
 
 See:
 https://packaging.python.org/tutorials/packaging-projects/


### PR DESCRIPTION
Since I copied `papermill` directly when creating `bookstore`, a missing `s` that @willingc found in https://github.com/nteract/bookstore/pull/1 was also present here. I have now typed more than 234x the characters that this PR introduces.