### PR TITLE
Anchorage

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -163,36 +163,40 @@ ERROR_MESSAGE_TEMPLATE = (
 )
 
 ID_MSG_TEMPLATE = "<h1 id={cell_id}>Cell ID {cell_id}<a href=#{cell_id}>¶</a></h1>"
+
+
 def add_cell_id_metadata(cells):
     for cell in cells:
         cell.metadata["papermill"] = cell.metadata.get("papermill", {})
-        if not cell.metadata.get("papermill",{}).get("cell_id"):
-            cell.metadata['papermill'].update({"cell_id": "a" + str(uuid.uuid4())}) 
+        if not cell.metadata.get("papermill", {}).get("cell_id"):
+            cell.metadata['papermill'].update({"cell_id": "a" + str(uuid.uuid4())})
     return cells
 
+
 def html_cells_with_anchors(cells):
-    other_cells = copy.deepcopy(cells)  
+    other_cells = copy.deepcopy(cells)
     for id, cell in enumerate(other_cells):
         cell_id = cell.metadata.get('papermill', {}).get("cell_id")
         id_msg = ID_MSG_TEMPLATE.format(cell_id=cell_id)
         other_cells[id] = nbformat.v4.new_code_cell(
             source="%%html\n" + id_msg,
             outputs=[
-                nbformat.v4.new_output(output_type="display_data", 
+                nbformat.v4.new_output(output_type="display_data",
                                        data={"text/html": id_msg})
             ],
             metadata={"inputHidden": True, "hide_input": True},
-            )
+        )
     return other_cells
+
 
 def raise_for_execution_errors(nb, output_path):
     error = None
     err_cell_id = ""
     old_cells = copy.deepcopy(nb.cells)
-    
+
     nb.cells = add_cell_id_metadata(nb.cells)
     nb.cells = list(itertools.chain(*zip(html_cells_with_anchors(nb.cells), nb.cells)))
-    
+
     for cell in nb.cells:
         if cell.get("outputs") is None:
             continue
@@ -211,7 +215,7 @@ def raise_for_execution_errors(nb, output_path):
 
     if error:
         # Write notebook back out with the Error Message at the top of the Notebook.
-        error_msg = ERROR_MESSAGE_TEMPLATE.format(err_cell_id=err_cell_id, 
+        error_msg = ERROR_MESSAGE_TEMPLATE.format(err_cell_id=err_cell_id,
                                                   count=str(error.exec_count))
         error_msg_cell = nbformat.v4.new_code_cell(
             source="%%html\n" + error_msg,

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -6,6 +6,7 @@ import os
 import six
 import copy
 import nbformat
+import uuid
 
 from .log import logger
 from .conf import settings
@@ -160,9 +161,16 @@ ERROR_MESSAGE_TEMPLATE = (
     '</span>'
 )
 
+def add_cell_id_metadata(cells):
+    for cell in cells:
+        cell.metadata["papermill"] = cell.metadata.get("papermill", {})
+        if not cell.metadata.get("papermill",{}).get("cell_id"):
+            cell.metadata['papermill'].update({"cell_id": str(uuid.uuid4())}) 
+    return cells
 
 def raise_for_execution_errors(nb, output_path):
     error = None
+    nb.cells = add_cell_id_metadata(nb.cells)
     for cell in nb.cells:
         if cell.get("outputs") is None:
             continue

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -7,6 +7,7 @@ import six
 import copy
 import nbformat
 import uuid
+import itertools
 
 from .log import logger
 from .conf import settings
@@ -188,7 +189,7 @@ def raise_for_execution_errors(nb, output_path):
     error = None
     err_cell_id = ""
     nb.cells = add_cell_id_metadata(nb.cells)
-    nb.cells = html_cells_with_anchors(nb.cells)
+    nb.cells = list(itertools.chain(*zip(html_cells_with_anchors(nb.cells), nb.cells)))
     
     for cell in nb.cells:
         if cell.get("outputs") is None:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -188,6 +188,8 @@ def html_cells_with_anchors(cells):
 def raise_for_execution_errors(nb, output_path):
     error = None
     err_cell_id = ""
+    old_cells = copy.deepcopy(nb.cells)
+    
     nb.cells = add_cell_id_metadata(nb.cells)
     nb.cells = list(itertools.chain(*zip(html_cells_with_anchors(nb.cells), nb.cells)))
     
@@ -221,3 +223,5 @@ def raise_for_execution_errors(nb, output_path):
         nb.cells = [error_msg_cell] + nb.cells
         write_ipynb(nb, output_path)
         raise error
+    else:
+        nb.cells = old_cells

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -162,7 +162,7 @@ ERROR_MESSAGE_TEMPLATE = (
     '</span>'
 )
 
-ID_MSG_TEMPLATE = "<h1 id={cell_id}>Cell ID {cell_id}<a href=#{cell_id}>¶</a></h1>"
+ID_MSG_TEMPLATE = "<a id={cell_id}></a>"
 
 
 def add_cell_id_metadata(cells):

--- a/papermill/tests/notebooks/broken1_id.ipynb
+++ b/papermill/tests/notebooks/broken1_id.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a5b5aae37-3189-47e7-87b5-441b56fb1afc'>'In [2]'</a>.</span>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a5b5aae37-3189-47e7-87b5-441b56fb1afc'>'In [2]'</a>.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a id=ad22dba11-ddbe-4598-b509-e2d564b9a592></a>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<a id=ad22dba11-ddbe-4598-b509-e2d564b9a592></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "papermill": {
+     "cell_id": "ad22dba11-ddbe-4598-b509-e2d564b9a592",
+     "duration": 0.019939,
+     "end_time": "2018-11-27T23:53:40.311206",
+     "exception": false,
+     "start_time": "2018-11-27T23:53:40.291267",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We're good.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"We're good.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a id=a5b5aae37-3189-47e7-87b5-441b56fb1afc></a>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<a id=a5b5aae37-3189-47e7-87b5-441b56fb1afc></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a5b5aae37-3189-47e7-87b5-441b56fb1afc",
+     "duration": 0.155997,
+     "end_time": "2018-11-27T23:53:40.470786",
+     "exception": true,
+     "start_time": "2018-11-27T23:53:40.314789",
+     "status": "failed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-a871fdc9ebee>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "assert False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a id=a38d9287f-c3a1-431c-86dc-3637527e490d></a>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<a id=a38d9287f-c3a1-431c-86dc-3637527e490d></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a38d9287f-c3a1-431c-86dc-3637527e490d",
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print \"Shouldn't get here.\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  },
+  "papermill": {
+   "duration": 2.288603,
+   "end_time": "2018-11-27T23:53:41.296020",
+   "environment_variables": {},
+   "exception": true,
+   "input_path": "papermill/tests/notebooks/broken1.ipynb",
+   "metrics": {
+    "duration": 3.6040260791778564
+   },
+   "output_path": "papermill/tests/notebooks/broken1_id.ipynb",
+   "parameters": {
+    "bar": "Hello World!",
+    "foo": 1.0
+   },
+   "start_time": "2018-11-27T23:53:39.007417",
+   "version": "0.4+2.ge10f94c.dirty"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/papermill/tests/notebooks/broken1_ids.ipynb
+++ b/papermill/tests/notebooks/broken1_ids.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a994bc1df-e442-4f6a-8fd7-5aa096f77984'>'In [2]'</a>.</span>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a994bc1df-e442-4f6a-8fd7-5aa096f77984'>'In [2]'</a>.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=a96a4b35f-6e6f-44cf-820b-8b055310bc5f>Cell ID a96a4b35f-6e6f-44cf-820b-8b055310bc5f<a href=#a96a4b35f-6e6f-44cf-820b-8b055310bc5f>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=a96a4b35f-6e6f-44cf-820b-8b055310bc5f>Cell ID a96a4b35f-6e6f-44cf-820b-8b055310bc5f<a href=#a96a4b35f-6e6f-44cf-820b-8b055310bc5f>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a96a4b35f-6e6f-44cf-820b-8b055310bc5f",
+     "duration": 0.017371,
+     "end_time": "2018-11-04T04:48:25.641995",
+     "exception": false,
+     "start_time": "2018-11-04T04:48:25.624624",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We're good.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"We're good.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=a994bc1df-e442-4f6a-8fd7-5aa096f77984>Cell ID a994bc1df-e442-4f6a-8fd7-5aa096f77984<a href=#a994bc1df-e442-4f6a-8fd7-5aa096f77984>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=a994bc1df-e442-4f6a-8fd7-5aa096f77984>Cell ID a994bc1df-e442-4f6a-8fd7-5aa096f77984<a href=#a994bc1df-e442-4f6a-8fd7-5aa096f77984>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a994bc1df-e442-4f6a-8fd7-5aa096f77984",
+     "duration": 0.113552,
+     "end_time": "2018-11-04T04:48:25.759226",
+     "exception": true,
+     "start_time": "2018-11-04T04:48:25.645674",
+     "status": "failed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-a871fdc9ebee>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "assert False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=a91c873df-4282-4c11-a6e0-409b1074ad3d>Cell ID a91c873df-4282-4c11-a6e0-409b1074ad3d<a href=#a91c873df-4282-4c11-a6e0-409b1074ad3d>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=a91c873df-4282-4c11-a6e0-409b1074ad3d>Cell ID a91c873df-4282-4c11-a6e0-409b1074ad3d<a href=#a91c873df-4282-4c11-a6e0-409b1074ad3d>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a91c873df-4282-4c11-a6e0-409b1074ad3d",
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print \"Shouldn't get here.\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  },
+  "papermill": {
+   "duration": 2.284794,
+   "end_time": "2018-11-04T04:48:26.679818",
+   "environment_variables": {},
+   "exception": true,
+   "input_path": "broken1.ipynb",
+   "metrics": {
+    "duration": 3.6040260791778564
+   },
+   "output_path": "broken1_ids.ipynb",
+   "parameters": {
+    "bar": "Hello World!",
+    "foo": 1.0
+   },
+   "start_time": "2018-11-04T04:48:24.395024",
+   "version": "0.4+2.ge10f94c.dirty"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/papermill/tests/notebooks/broken2_ids.ipynb
+++ b/papermill/tests/notebooks/broken2_ids.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a7c7dc355-7035-46b8-b445-918640fa3c5f'>'In [2]'</a>.</span>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at <a href='#a7c7dc355-7035-46b8-b445-918640fa3c5f'>'In [2]'</a>.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=a83c14c5b-41bc-4c4d-a406-f1630794c430>Cell ID a83c14c5b-41bc-4c4d-a406-f1630794c430<a href=#a83c14c5b-41bc-4c4d-a406-f1630794c430>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=a83c14c5b-41bc-4c4d-a406-f1630794c430>Cell ID a83c14c5b-41bc-4c4d-a406-f1630794c430<a href=#a83c14c5b-41bc-4c4d-a406-f1630794c430>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a83c14c5b-41bc-4c4d-a406-f1630794c430",
+     "duration": 0.01978,
+     "end_time": "2018-11-04T04:59:39.101069",
+     "exception": false,
+     "start_time": "2018-11-04T04:59:39.081289",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We're good.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"We're good.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=a7c7dc355-7035-46b8-b445-918640fa3c5f>Cell ID a7c7dc355-7035-46b8-b445-918640fa3c5f<a href=#a7c7dc355-7035-46b8-b445-918640fa3c5f>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=a7c7dc355-7035-46b8-b445-918640fa3c5f>Cell ID a7c7dc355-7035-46b8-b445-918640fa3c5f<a href=#a7c7dc355-7035-46b8-b445-918640fa3c5f>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "papermill": {
+     "cell_id": "a7c7dc355-7035-46b8-b445-918640fa3c5f",
+     "duration": 0.113298,
+     "end_time": "2018-11-04T04:59:39.217812",
+     "exception": true,
+     "start_time": "2018-11-04T04:59:39.104514",
+     "status": "failed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.container { width:100% !important; }</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-7e661b986a57>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mHTML\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"<style>.container { width:100% !important; }</style>\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0;32massert\u001b[0m \u001b[0mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "# This causes multiple output elements to be created, one of type \"display_data\" and another of type \"error.\"\n",
+    "from IPython.core.display import display, HTML\n",
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
+    "\n",
+    "assert False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "hide_input": true,
+    "inputHidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h1 id=aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6>Cell ID aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6<a href=#aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6>¶</a></h1>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<h1 id=aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6>Cell ID aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6<a href=#aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6>¶</a></h1>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "cell_id": "aa84b4f79-0f8e-4cff-a5fb-9d388b6b14b6",
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print \"Shouldn't get here.\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  },
+  "papermill": {
+   "duration": 2.280625,
+   "end_time": "2018-11-04T04:59:40.134197",
+   "environment_variables": {},
+   "exception": true,
+   "input_path": "broken2.ipynb",
+   "metrics": {
+    "duration": 3.6040260791778564
+   },
+   "output_path": "broken2_ids.ipynb",
+   "parameters": {
+    "bar": "Hello World!",
+    "foo": 1.0
+   },
+   "start_time": "2018-11-04T04:59:37.853572",
+   "version": "0.4+2.ge10f94c.dirty"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/papermill/tests/notebooks/simple_execute_ids.ipynb
+++ b/papermill/tests/notebooks/simple_execute_ids.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "papermill": {
+     "duration": 0.010102,
+     "end_time": "2018-11-04T04:48:48.195391",
+     "exception": false,
+     "start_time": "2018-11-04T04:48:48.185289",
+     "status": "completed"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msg = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "papermill": {
+     "duration": 0.009147,
+     "end_time": "2018-11-04T04:48:48.207573",
+     "exception": false,
+     "start_time": "2018-11-04T04:48:48.198426",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(msg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "papermill": {
+     "duration": 0.002704,
+     "end_time": "2018-11-04T04:48:48.213651",
+     "exception": false,
+     "start_time": "2018-11-04T04:48:48.210947",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  },
+  "papermill": {
+   "duration": 1.567031,
+   "end_time": "2018-11-04T04:48:48.742270",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "simple_execute.ipynb",
+   "output_path": "simple_execute_ids.ipynb",
+   "parameters": {},
+   "start_time": "2018-11-04T04:48:47.175239",
+   "version": "0.15.1+28.g641a95d.dirty"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -138,10 +138,10 @@ class TestBrokenNotebook1(unittest.TestCase):
         nb = read_notebook(result_path)
         self.assertEqual(nb.node.cells[0].cell_type, "code")
         self.assertEqual(nb.node.cells[0].outputs[0].output_type, "display_data")
-        self.assertEqual(nb.node.cells[1].execution_count, 1)
-        self.assertEqual(nb.node.cells[2].execution_count, 2)
-        self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'error')
-        self.assertEqual(nb.node.cells[3].execution_count, None)
+        self.assertEqual(nb.node.cells[2].execution_count, 1)
+        self.assertEqual(nb.node.cells[4].execution_count, 2)
+        self.assertEqual(nb.node.cells[4].outputs[0].output_type, 'error')
+        self.assertEqual(nb.node.cells[6].execution_count, None)
 
 
 class TestBrokenNotebook2(unittest.TestCase):
@@ -159,11 +159,11 @@ class TestBrokenNotebook2(unittest.TestCase):
         nb = read_notebook(result_path)
         self.assertEqual(nb.node.cells[0].cell_type, "code")
         self.assertEqual(nb.node.cells[0].outputs[0].output_type, "display_data")
-        self.assertEqual(nb.node.cells[1].execution_count, 1)
-        self.assertEqual(nb.node.cells[2].execution_count, 2)
-        self.assertEqual(nb.node.cells[2].outputs[0].output_type, 'display_data')
-        self.assertEqual(nb.node.cells[2].outputs[1].output_type, 'error')
-        self.assertEqual(nb.node.cells[3].execution_count, None)
+        self.assertEqual(nb.node.cells[2].execution_count, 1)
+        self.assertEqual(nb.node.cells[4].execution_count, 2)
+        self.assertEqual(nb.node.cells[4].outputs[0].output_type, 'display_data')
+        self.assertEqual(nb.node.cells[4].outputs[1].output_type, 'error')
+        self.assertEqual(nb.node.cells[6].execution_count, None)
 
 
 class TestNBConvertCalls(unittest.TestCase):


### PR DESCRIPTION
This is a PR that should make it easier to navigate to the cell that was in error when you run into an error. Specifically, it allows you to click on a link that jumps you right to the cell where the error occurred.

How does it do this?

1. Give each cell a unique id
2. Create a new collection of cells that add anchors to the page tying that unique id to that location in the DOM
3. Modifies the error message being inserted at the top of the page to include an anchor link to the cell in error.

It does nothing if there is no error. 

I think I'd want to include tests for the new apis that this introduces before we released this, but I want to iterate a couple of times first on the exact form this should take. 

But nonetheless the existing tests needed to be modified to pass as of this latest commit.