### PR TITLE
Add azure blob storage backend support

### DIFF
--- a/papermill/abs.py
+++ b/papermill/abs.py
@@ -1,0 +1,65 @@
+import re
+from six.moves import urllib
+from azure.storage.blob import BlockBlobService
+
+
+class AzureBlobStore(object):
+
+    def __init__(self):
+        pass
+
+    def _block_blob_service(self, account_name, sas_token):
+
+        block_blob_service = BlockBlobService(
+            account_name=account_name, sas_token=sas_token
+        )
+        return block_blob_service
+
+    @classmethod
+    def _split_url(self, url):
+        """
+        see: https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1  # noqa: E501
+        abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken
+        """
+        match = re.match(
+            r"abs://(.*)\.blob\.core\.windows\.net\/(.*)\/(.*)\?(.*)$", url
+        )
+        if not match:
+            raise Exception("Invalid azure blob url '{0}'".format(url))
+        else:
+            params = {
+                "account": match.group(1),
+                "container": match.group(2),
+                "blob": match.group(3),
+                "sas_token": urllib.parse.unquote_plus(match.group(4)),
+            }
+            return params
+
+    def read(self, url):
+        params = self._split_url(url)
+        block_blob_service = self._block_blob_service(
+            account_name=params["account"], sas_token=params["sas_token"]
+        )
+        return block_blob_service.get_blob_to_text(
+            container_name=params["container"], blob_name=params["blob"]
+        )
+
+    def listdir(self, url):
+        params = self._split_url(url)
+
+        block_blob_service = self._block_blob_service(
+            account_name=params["account"], sas_token=params["sas_token"]
+        )
+        blobs = block_blob_service.list_blobs(params["container"])
+        return blobs
+
+    def write(self, buf, url):
+        params = self._split_url(url)
+
+        block_blob_service = self._block_blob_service(
+            account_name=params["account"], sas_token=params["sas_token"]
+        )
+
+        block_blob_service.create_blob_from_text(
+            container_name=params["container"], blob_name=params["blob"], text=buf
+        )

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -16,6 +16,7 @@ from . import __version__
 from .exceptions import PapermillException
 from .s3 import S3
 from .adl import ADL
+from .abs import AzureBlobStore
 
 try:
     FileNotFoundError
@@ -184,11 +185,39 @@ class ADLHandler(object):
         return path
 
 
+class ABSHandler(object):
+    _client = None
+
+    @classmethod
+    def _get_client(cls):
+        if cls._client is None:
+            cls._client = AzureBlobStore()
+        return cls._client
+
+    @classmethod
+    def read(cls, path):
+        lines = cls._get_client().read(path)
+        return "\n".join(lines)
+
+    @classmethod
+    def listdir(cls, path):
+        return cls._get_client().listdir(path)
+
+    @classmethod
+    def write(cls, buf, path):
+        return cls._get_client().write(buf, path)
+
+    @classmethod
+    def pretty_path(cls, path):
+        return path
+
+
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_io = PapermillIO()
 papermill_io.register("local", LocalHandler)
 papermill_io.register("s3://", S3Handler)
 papermill_io.register("adl://", ADLHandler)
+papermill_io.register("abs://", ABSHandler)
 papermill_io.register("http://", HttpHandler)
 papermill_io.register("https://", HttpHandler)
 

--- a/papermill/tests/test_abs.py
+++ b/papermill/tests/test_abs.py
@@ -1,0 +1,79 @@
+import unittest
+import six
+
+from ..abs import AzureBlobStore
+
+if six.PY3:
+    from unittest.mock import Mock
+else:
+    from mock import Mock
+
+
+class ABSTest(unittest.TestCase):
+    """
+    Tests for `ABS`
+    """
+
+    def setUp(self):
+        self.list_blobs = Mock(return_value=["foo", "bar", "baz"])
+        self.get_blob_to_text = Mock(return_value=["hello"])
+        self.create_blob_from_text = Mock()
+        self._block_blob_service = Mock(
+            get_blob_to_text=self.get_blob_to_text,
+            list_blobs=self.list_blobs,
+            create_blob_from_text=self.create_blob_from_text,
+        )
+        self.abs = AzureBlobStore()
+        self.abs._block_blob_service = Mock(return_value=self._block_blob_service)
+
+    def test_split_url_raises_exception_on_invalid_url(self):
+        with self.assertRaises(Exception) as context:
+            AzureBlobStore._split_url("this_is_not_a_valid_url")
+        self.assertTrue(
+            "Invalid azure blob url 'this_is_not_a_valid_url'" in str(context.exception)
+        )
+
+    def test_split_url_splits_valid_url(self):
+        params = AzureBlobStore._split_url(
+            "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken"
+        )
+        self.assertEqual(params["account"], "myaccount")
+        self.assertEqual(params["container"], "sascontainer")
+        self.assertEqual(params["blob"], "sasblob.txt")
+        self.assertEqual(params["sas_token"], "sastoken")
+
+    def test_listdir_calls(self):
+        self.assertEqual(
+            self.abs.listdir(
+                "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken"
+            ),
+            ["foo", "bar", "baz"],
+        )
+        self.list_blobs.assert_called_once_with("sascontainer")
+
+    def test_reads_file(self):
+        self.assertEquals(
+            self.abs.read(
+                "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken"
+            ),
+            ["hello"],
+        )
+        self.get_blob_to_text.assert_called_once_with(
+            container_name="sascontainer", blob_name="sasblob.txt"
+        )
+
+    def test_write_file(self):
+        self.abs.write(
+            "hello world",
+            "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken",
+        )
+        self.create_blob_from_text.assert_called_once_with(
+            container_name="sascontainer", blob_name="sasblob.txt", text="hello world"
+        )
+
+    def test__block_blob_service(self):
+        abs = AzureBlobStore()
+        blob = abs._block_blob_service(account_name="myaccount", sas_token="sastoken")
+        self.assertEqual(blob.account_name, "myaccount")
+        self.assertEqual(blob.sas_token, "sastoken")
+        self.assertEqual(blob.blob_type, "BlockBlob")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ mock
 pytest>=3.3
 pytest-cov
 pytest-mock
-moto>=1.2.0
+moto>=1.2.0, <=1.3.6
 check-manifest
 black; python_version >= '3.6'
 attrs>=17.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ jupyter_client
 pandas
 requests
 azure-datalake-store >= 0.0.30
+azure-storage-blob


### PR DESCRIPTION
Azure blob storage backend are made available using the abs:// prefix. 

Access will be granted using shared access signatures (SAS) (see https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1)

This pull request addresses the issue https://github.com/nteract/papermill/issues/205

