### PR TITLE
Fixed botocore change break.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ matrix:
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       # Try removing the google-compute-engine when this doesn't require sudo
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+# For some reason the pytest.ini isn't being respected
+env:
+  global:
+    - AWS_ACCESS_KEY_ID=foobar_key
+    - AWS_SECRET_ACCESS_KEY=foobar_secret
 install:
   - pip install setuptools pip --upgrade
   - pip install -e .[test]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include papermill *.txt
 include setup.py
 include requirements.txt
 include requirements-dev.txt
+include pytest.ini
 include README.rst
 include LICENSE
 include MANIFEST.in

--- a/papermill/_version.py
+++ b/papermill/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/papermill/abs.py
+++ b/papermill/abs.py
@@ -4,15 +4,12 @@ from azure.storage.blob import BlockBlobService
 
 
 class AzureBlobStore(object):
-
     def __init__(self):
         pass
 
     def _block_blob_service(self, account_name, sas_token):
 
-        block_blob_service = BlockBlobService(
-            account_name=account_name, sas_token=sas_token
-        )
+        block_blob_service = BlockBlobService(account_name=account_name, sas_token=sas_token)
         return block_blob_service
 
     @classmethod
@@ -21,9 +18,7 @@ class AzureBlobStore(object):
         see: https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1  # noqa: E501
         abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken
         """
-        match = re.match(
-            r"abs://(.*)\.blob\.core\.windows\.net\/(.*)\/(.*)\?(.*)$", url
-        )
+        match = re.match(r"abs://(.*)\.blob\.core\.windows\.net\/(.*)\/(.*)\?(.*)$", url)
         if not match:
             raise Exception("Invalid azure blob url '{0}'".format(url))
         else:

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -136,22 +136,17 @@ class LocalHandler(object):
 
 
 class S3Handler(object):
-    keyname = None
-
     @classmethod
     def read(cls, path):
-        s3_client = S3(keyname=cls.keyname)
-        return "\n".join(s3_client.read(path))
+        return "\n".join(S3().read(path))
 
     @classmethod
     def listdir(cls, path):
-        s3_client = S3(keyname=cls.keyname)
-        return s3_client.listdir(path)
+        return S3().listdir(path)
 
     @classmethod
     def write(cls, buf, path):
-        s3_client = S3(keyname=cls.keyname)
-        return s3_client.cp_string(buf, path)
+        return S3().cp_string(buf, path)
 
     @classmethod
     def pretty_path(cls, path):

--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -1,28 +1,16 @@
 # -*- coding: utf-8 -*-
 """Utilities for working with S3."""
 from __future__ import unicode_literals
-from past.builtins import basestring, str
 
-from concurrent import futures
-import fnmatch
-from functools import wraps, reduce
-import gzip
-import itertools
 import logging
-import os
-import re
-import shutil
-import tempfile
 import threading
 import zlib
-
-
-import boto3
-from boto3.session import Session
-
 import six
 
-from .exceptions import AwsError, FileExistsError
+from boto3.session import Session
+
+from .exceptions import AwsError
+from .utils import retry
 
 
 logger = logging.getLogger('papermill.s3')
@@ -133,24 +121,6 @@ class Key(object):
         return self.__str__()
 
 
-# retry decorator
-def retry(num):
-    def decorate(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            for i in range(num):
-                try:
-                    return func(*args, **kwargs)
-                except Exception as e:
-                    logger.debug('retrying: {}'.format(e))
-            else:
-                raise Exception  # TODO verify what to raise
-
-        return wrapper
-
-    return decorate
-
-
 class S3(object):
     """
     Wraps S3.
@@ -158,97 +128,30 @@ class S3(object):
     Parameters
     ----------
     keyname : TODO
-    use_akms : bool, optional (Default is None) (TODO What is akms? Kinesis?)
-    host : DEPRECATED. string, optional (Default is None)
-    region : string, optional (Default is 'us-east-1')
 
     Methods
     -------
     The following are wrapped utilities for S3:
         - cat
-        - catdir (TODO refactor to cat_dir)
-        - cp
-        - cpdir (TODO cp_dir)
-        - cpmerge (TODO cp_merge)
         - cp_string
-        - get_key
         - list
-        - list_buckets
         - list_dir
-        - list_dir_iterator
-        - list_glob
-        - list_globs
-        - new_folder
-        - readdir (TODO read_dir)
         - read
-        - rm
-        - rmdir (TODO rm_dir)
 
     """
 
-    sessions = {}
+    s3_session = (None, None, None)
     lock = threading.RLock()
 
-    # TODO: add support for assume role.
-
-    def __init__(self, keyname=None, use_akms=None, host=None, region='us-east-1', *args, **kwargs):
-
-        import botocore.session
-
-        # DEPRECATED - `host`
-        if host:
-            logger.warning('the host param is deprecated')
-
-        use_akms = use_akms if use_akms is not None else 'USE_AKMS' in os.environ
-
-        args = (keyname, use_akms)
+    def __init__(self, keyname=None, *args, **kwargs):
         with self.lock:
-            if args not in self.sessions:
-                session = Session(
-                    botocore_session=botocore.session.Session(
-                        session_vars={'akms_keyname': keyname, 'use_akms': use_akms}
-                    )
-                )
+            if not all(S3.s3_session):
+                session = Session()
                 client = session.client('s3')
                 s3 = session.resource('s3')
-                self.sessions[args] = (session, client, s3)
+                S3.s3_session = (session, client, s3)
 
-        (self.session, self.client, self.s3) = self.sessions[args]
-
-    def __batches(self, it, size=1000):
-        while True:
-            data = itertools.islice(it, size)
-            batch = list(data)
-            if not batch:
-                break
-            yield batch
-
-    def __create_callback(self, filename, total=None, callback=None):
-        if callback is None:
-            cur = 0  # noqa TODO refactor cur name
-
-            class Callback(object):
-                def __init__(self, total):
-                    self.cur = 0
-                    self.total = total
-
-                def __call__(self, retr):
-
-                    if self.total:
-                        self.cur += retr  # TODO refactor cur and retr names
-                        logger.debug(
-                            '%s: %6d/%dkb (%3.2f%% Complete)' % filename,
-                            self.cur / 1024,
-                            self.total / 1024,
-                            self.cur / float(total) * 100,
-                        )
-
-        return callback
-
-    def _bucket(self, bucket):
-        if isinstance(bucket, Key):
-            return bucket.bucket
-        return Bucket(self._bucket_name(bucket), service=self)
+        (self.session, self.client, self.s3) = S3.s3_session
 
     def _bucket_name(self, bucket):
         return self._clean(bucket).split('/', 1)[0]
@@ -263,50 +166,11 @@ class S3(object):
     def _clean_s3(self, name):
         return 's3:' + name[4:] if name.startswith('s3n:') else name
 
-    @retry(3)
-    def _copy(self, source, dest):
-        key = self._get_key(dest)
-        source_key = self._get_key(source)
-        obj = self.s3.Object(key.bucket.name, key.name)
-        obj.copy_from(CopySource='{}/{}'.format(source_key.bucket.name, source_key.name))
-        return key
-
-    @retry(3)
-    def _get(self, source, dest=None, num_callbacks=10, **kwargs):
-        assert dest is not None, 'a destination must be provided'
-
-        targetFile = isinstance(dest, six.string_types)
-        if targetFile:
-            tmpfile = tempfile.NamedTemporaryFile()
-        else:
-            tmpfile = dest
-
-        try:
-            key = self._get_key(source)
-            obj = self.s3.Object(key.bucket.name, key.name)
-            obj.load()
-            obj.download_fileobj(
-                tmpfile,
-                Callback=self.__create_callback(
-                    source, total=obj.content_length, callback=kwargs.get('callback')
-                ),
-            )
-            if targetFile:
-                tmpfile.seek(0)
-                shutil.copyfileobj(tmpfile, open(dest, 'wb'))
-            return key
-        finally:
-            if targetFile:
-                tmpfile.close()
-
     def _get_key(self, name):
         if isinstance(name, Key):
             return name
 
         return Key(bucket=self._bucket_name(name), name=self._key_name(name), service=self)
-
-    def _get_file_obj(self, f, mode='wb'):
-        return gzip.open(f, mode) if f.endswith('.gz') else open(f, mode)
 
     def _key_name(self, name):
         cleaned = self._clean(name).split('/', 1)
@@ -368,26 +232,13 @@ class S3(object):
     def _put(self, source, dest, num_callbacks=10, policy='bucket-owner-full-control', **kwargs):
         key = self._get_key(dest)
         obj = self.s3.Object(key.bucket.name, key.name)
-        length = 0
 
         # support passing in open file obj.  Why did we do this in the past?
 
         if not isinstance(source, six.string_types):
-            obj.upload_fileobj(
-                source,
-                ExtraArgs={'ACL': policy},
-                Callback=self.__create_callback(
-                    dest, total=os.fstat(source.fileno()).st_size, callback=kwargs.get('callback')
-                ),
-            )
+            obj.upload_fileobj(source, ExtraArgs={'ACL': policy})
         else:
-            obj.upload_file(
-                source,
-                ExtraArgs={'ACL': policy},
-                Callback=self.__create_callback(
-                    dest, total=length, callback=kwargs.get('callback')
-                ),
-            )
+            obj.upload_file(source, ExtraArgs={'ACL': policy})
         return key
 
     def _put_string(
@@ -396,24 +247,18 @@ class S3(object):
         key = self._get_key(dest)
         obj = self.s3.Object(key.bucket.name, key.name)
 
-        if isinstance(source, str):
+        if isinstance(source, six.string_types):
             source = source.encode('utf-8')
         obj.put(Body=source, ACL=policy)
         return key
 
     def _is_s3(self, name):
         # only allow file objects from local
-        if not isinstance(name, (basestring, Key, Prefix)):
+        if not isinstance(name, six.string_types + (Key, Prefix)):
             return False
 
         name = self._clean_s3(name)
         return 's3://' in name
-
-    def _sizeof(self, key, bucket=None):
-        assert bucket is not None, 'You must specify a bucket'
-
-        response = self.client.head_object(Bucket=bucket, Key=key)
-        return response['ContentLength']
 
     def cat(
         self,
@@ -507,99 +352,6 @@ class S3(object):
                 decoded = undecoded.decode(encoding)
                 yield decoded
 
-    def catdir(self, source, buffersize=None, compressed=False, encoding='UTF-8'):
-        """
-        Iterates over a dir in s3 split on newline.
-
-        Yields chunks of data from the file.
-
-        """
-        for f in self.listdir(source, keys=True):
-            logger.debug('S3.catdir: %s', f)
-            full_name = 's3://{}/{}'.format(f.bucket.name, f.name)
-            for l in self.cat(
-                full_name, buffersize=buffersize, compressed=compressed, encoding=encoding
-            ):
-                yield l
-
-    def cp(self, source, dest, **kwargs):
-        """
-        Copies to and from an s3 bucket to a file.
-
-        The source and destination should be the fully qualified path of an
-        s3 key and the filename to copy from/to.
-
-        """
-        fr = self._is_s3(source)
-        to = self._is_s3(dest)
-        if fr and to:
-            return self._copy(source, dest, **kwargs)
-        elif fr:
-            return self._get(source, dest, **kwargs)
-        else:
-            return self._put(source, dest, **kwargs)
-
-    def cpdir(self, source, dest, recursive=True, **kwargs):
-        """
-        Copies to and from an s3 prefix to a directory.  The source and
-        destination should be the fully qualified path of an s3 prefix and the
-        directory to copy from/to.
-
-        """
-        source = source.endswith('/') and source or "%s/" % source
-        source = self._clean_s3(source)
-        dest = re.sub('/$', '', dest)
-
-        fr = self._is_s3(source)
-        to = self._is_s3(dest)
-
-        if fr:
-            for i in list(self.listdir(source)):
-                file = "%s/%s" % (dest, i.replace(source, ''))
-                if not i.endswith('/'):
-                    self.cp(i, file, **kwargs)
-                elif recursive:
-                    if not to and not os.path.exists(file):
-                        os.makedirs(file)
-                    self.cpdir(i, file, recursive=recursive, **kwargs)
-        else:
-            for i in os.listdir(source):
-                s = "%s/%s" % (source, i)
-                d = "%s/%s" % (dest, i)
-                if recursive and os.path.isdir(s):
-                    self.cpdir(s, d, recursive=recursive, **kwargs)
-                else:
-                    self._put(s, d, **kwargs)
-
-    def cpmerge(self, source, dest):
-        """
-        Takes a source directory and a destination file as input and
-        concatenates files in src into the destination local file.
-
-        """
-        fr = self._is_s3(source)
-        to = self._is_s3(dest)
-
-        if fr and not to:
-            if os.path.isfile(dest):
-                raise FileExistsError("File {} already exists".format(dest))
-            if os.path.isdir(dest):
-                raise AwsError("Destination {} is a directory".format(dest))
-
-            try:
-                os.makedirs(os.path.dirname(dest))
-            except (OSError) as e:
-                if e.strerror != 'File exists':
-                    raise
-
-            with self._get_file_obj(dest) as outfile:
-                for f in self.listdir(source):
-                    logger.debug('reading {}'.format(f))
-                    for line in self.cat(f, compressed=f.endswith('gz')):
-                        outfile.write(line)
-        else:
-            raise AwsError("Copy-merging {} to {} is not supported".format(source, dest))
-
     def cp_string(self, source, dest, **kwargs):
         """
         Copies source string into the destination location.
@@ -610,48 +362,12 @@ class S3(object):
             the string with the content to copy
         dest: string
             the s3 location
-
-        Uses basestring type (python2) when checking if a string
-
         """
 
-        assert isinstance(source, basestring), "source must be a string"
+        assert isinstance(source, six.string_types), "source must be a string"
         assert self._is_s3(dest), "Destination must be s3 location"
 
         return self._put_string(source, dest, **kwargs)
-
-    def get_key(self, name):
-        """
-        Get Key object if the name represents a key, otherwise return None.
-
-        Examples:
-
-        >>> s3.get_key('s3://netflix-dataoven-test-users/jwalton/nothing.py')
-
-            <Key: netflix-dataoven-test-users,jwalton/nothing.py>
-
-        >>> s3.get_key('s3://netflix-dataoven-test-users/jwalton/')
-
-            None
-
-        Args:
-           name (str): the full s3 location for which to get the key
-
-        Returns:
-           A boto3.resources.factory.s3.Object object if the name represents
-           a file or None if the name is a prefix
-
-        """
-        assert self._is_s3(name), "location must be in form s3://bucket/key"
-
-        key = self._get_key(name)
-        try:
-            obj = self.s3.Object(key.bucket.name, key.name)
-            obj.load()
-            return obj
-        except boto3.exceptions.botocore.exceptions.ClientError as e:
-            logger.debug(e)
-            pass
 
     def list(self, name, iterator=False, **kwargs):
         """
@@ -676,9 +392,6 @@ class S3(object):
 
         it = self._list(bucket=self._bucket_name(name), prefix=self._key_name(name), **kwargs)
         return iter(it) if iterator else list(it)
-
-    def list_buckets(self):
-        return [bucket['Name'] for bucket in self.client.list_buckets().get('Buckets', [])]
 
     def listdir(self, name, **kwargs):
         """
@@ -705,95 +418,6 @@ class S3(object):
             name += "/"
         return self.list(name, delimiter='/', **kwargs)
 
-    def listdir_iterator(self, name):
-        """
-        Iterates over a list of objects in a bucket.
-
-        Calls `bucket.list` which returns a
-        `boto.s3.bucketlistresultset.bucketlistresultset`
-
-        Items returned from iterator are `boto` `objects`.
-
-        """
-        assert self._is_s3(name), "name must be in form s3://bucket/key"
-
-        return self._list(
-            prefix=self._key_name(name), bucket=self._bucket_name(name), objects=True, delimiter='/'
-        )
-
-    def listglob(self, glb, **kwargs):
-        """
-        Returns a list of the files matching a glob.
-
-        Name must be in the form of s3://bucket/glob
-
-        """
-        r = []
-        regex = re.compile(r'[*?\[]')
-        for file in self.list(regex.split(glb, 1)[0], **kwargs):
-            if fnmatch.fnmatch(str(file), glb):
-                r.append(file)
-        return r
-
-    def listglobs(self, *args, **kwargs):
-        """
-        Returns a list of files for multiple glob operators.
-
-        Equivalent to list(listglob(args[0])) + list(listglob(args[1]))  + ...
-
-        Use Python lambda and reduce
-
-        arguments acc and x
-        sequence acc + x
-        executor.map(self.listglob, args)
-        []
-
-        The function reduce(func, seq) continually applies the function
-        func() to the sequence seq. It returns a single value.
-
-        """
-        with futures.ThreadPoolExecutor(max_workers=kwargs.get('threads', len(args))) as executor:
-            out = reduce(lambda acc, x: acc + x, executor.map(self.listglob, args), [])
-        return out
-
-    def new_folder(self, name):
-        """
-        Creates a new "folder" by adding a file called "_empty" under the prefix given.
-
-        Example:
-            >>> s3.new_folder('s3://thebucket/somedir/newdir/')
-
-        Args:
-            name - the full location for the new "folder" in the format s3://bucket/prefix
-
-        Returns: key for the new "folder"
-
-        """
-        assert self._is_s3(name), "name must be in form s3://bucket/new_key/"
-
-        if not name.endswith("/"):
-            name += "/"
-
-        existing = self.get_key(name)
-        if existing is not None:
-            raise Exception("key {} already exists".format(name))
-
-        loc = name + "_empty"
-        self._put_string("", loc)
-
-        return self.get_key(name)
-
-    def readdir(self, source, compressed=False, encoding='UTF-8'):
-        """
-        Iterates over a dir in s3 split on newline.
-
-        Yields line in file in dir.
-
-        """
-        for f in self.listdir(source, keys=True):
-            for l in self.read(str(f), compressed=compressed, encoding=encoding):
-                yield l
-
     def read(self, source, compressed=False, encoding='UTF-8'):
         """
         Iterates over a file in s3 split on newline.
@@ -816,59 +440,3 @@ class S3(object):
         # only yield the last line if the line has content in it
         if lines[-1]:
             yield lines[-1]
-
-    def rm(self, target):
-        """
-        Remove a single key from s3.
-
-        If you want to remove a directory use rmdir.
-
-        """
-        assert self._is_s3(target), 'target must be a valid s3 path'
-
-        key = self._get_key(target)
-        if key:
-            obj = self.s3.Object(key.bucket.name, key.name)
-            return obj.delete()
-
-    def rmdir(self, target, delimiter='/'):
-        """Removes every key that falls under the target directory."""
-        assert self._is_s3(target), 'target must be a valid s3 path'
-
-        bucket = self.s3.Bucket(self._bucket_name(target))
-        errors = []
-        for batch in self.__batches(
-            self._list(bucket=self._bucket_name(target), prefix=self._key_name(target), keys=True)
-        ):
-            keys = [dict(Key=n.name) for n in batch]
-            response = bucket.delete_objects(Delete={'Objects': keys})
-            if 'Errors' in response:
-                errors += response['Errors']
-        if errors:
-            logger.warning("errors deleting: {}".format(errors))
-
-
-# leaving this here for compatibility
-def split(path):
-    """
-    Splits an s3 path into bucket and prefix, like `os.path.split`.
-
-    It can only be used once.
-
-    For example, `s3://foo/bar/baz` would return `['foo','bar/baz']`
-
-    .. note::
-       A trailing `/` is significant in s3, and it will not be stripped,
-       ie `s3://foo/bar/baz/` will return `['foo','bar/baz/']`
-
-    """
-    if not path.startswith('s3://'):
-        raise ValueError('path must start with s3://')
-    path = path[5:]
-    if path:
-        if '/' in path:
-            return path.split('/', 1)
-        else:
-            return [path, '']
-    else:
-        return ['', '']

--- a/papermill/tests/test_abs.py
+++ b/papermill/tests/test_abs.py
@@ -64,8 +64,7 @@ class ABSTest(unittest.TestCase):
 
     def test_write_file(self):
         self.abs.write(
-            "hello world",
-            "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken",
+            "hello world", "abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken"
         )
         self.create_blob_from_text.assert_called_once_with(
             container_name="sascontainer", blob_name="sasblob.txt", text="hello world"

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+import six
+
+from ..utils import retry
+
+if six.PY3:
+    from unittest.mock import Mock, call
+else:
+    from mock import Mock, call
+
+
+def test_retry():
+    m = Mock(side_effect=RuntimeError(), __name__="m", __module__="test_s3", __doc__="m")
+    wrapped_m = retry(3)(m)
+    with pytest.raises(RuntimeError):
+        wrapped_m("foo")
+    m.assert_has_calls([call("foo"), call("foo"), call("foo")])

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -1,0 +1,27 @@
+import logging
+
+from functools import wraps
+
+
+logger = logging.getLogger('papermill.utils')
+
+
+# retry decorator
+def retry(num):
+    def decorate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            exception = None
+
+            for i in range(num):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    logger.debug('Retrying after: {}'.format(e))
+                    exception = e
+            else:
+                raise exception
+
+        return wrapper
+
+    return decorate

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+env =
+    AWS_SECRET_ACCESS_KEY=foobar_secret
+    AWS_ACCESS_KEY_ID=foobar_key

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,13 +5,13 @@ mock
 pytest>=3.3
 pytest-cov
 pytest-mock
-moto>=1.2.0, <=1.3.6
+pytest-env
+moto
 check-manifest
 black; python_version >= '3.6'
 attrs>=17.4.0
 pre-commit
-# Until https://github.com/spulec/moto/issues/1793 is resolved
-boto3 < 1.8.0
-botocore < 1.11.0
+boto3
+botocore
 ipywidgets
 flake8

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.


### PR DESCRIPTION
This needs to be merged asap as papermill is broken with recent boto versions. Tested with some basic s3 notebooks on python 2 and 3 beyond the unittests.

Also fixed the moto test breakage so we can unpin botocore and moto.

The lines touched outside of s3 are the result of black / flake passes cleaning up stray lines.

Took the opportunity to strip out all the unused junk in s3.py. This brings out test coverage up to 90% :confetti_ball: 