### PR TITLE
Do not set logging level on import

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import base64
+import logging
 
 import click
 
@@ -95,6 +96,8 @@ def papermill(
     output in the destination notebook.
 
     """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     if progress_bar is None:
         progress_bar = not log_output
 

--- a/papermill/log.py
+++ b/papermill/log.py
@@ -1,4 +1,3 @@
 import logging
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger('papermill')


### PR DESCRIPTION
When papermill is imported, the logging level was automatically being
set to `INFO`. Many Python libraries are chatty at that logging level
which leads to confusing messages when a user executes a Jupyter
notebook that imports `papermill` and also uses another Python library
to perform some task.

Logging will work correctly even if the call to `logging.basicConfig`
is omitted. It will simply log at the default logging level of the
environment.

Libraries in general should not change the logging level of the
environment at the import level, since this confuses users and is
difficult for users to understand what went wrong when they see
messages they don't expect nor, in many cases, understand.

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>