### PR TITLE
Allow custom handlers via entry points

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -4,6 +4,7 @@ import datetime
 import dateutil
 
 from functools import wraps
+import entrypoints
 
 from .log import logger
 from .exceptions import PapermillException
@@ -33,6 +34,11 @@ class PapermillEngines(object):
 
     def register(self, name, engine):
         self._engines[name] = engine
+
+    def register_entry_points(self):
+        # Load handlers provided by other packages
+        for entrypoint in entrypoints.get_group_all("papermill.engine"):
+            self.register(entrypoint.name, entrypoint.load())
 
     def get_engine(self, name=None):
         """

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -340,3 +340,4 @@ class NBConvertEngine(Engine):
 papermill_engines = PapermillEngines()
 papermill_engines.register(None, NBConvertEngine)
 papermill_engines.register('nbconvert', NBConvertEngine)
+papermill_engines.register_entry_points()

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -12,6 +12,8 @@ import yaml
 import fnmatch
 import warnings
 
+import entrypoints
+
 from . import __version__
 from .exceptions import PapermillException
 from .s3 import S3
@@ -75,6 +77,11 @@ class PapermillIO(object):
     def register(self, scheme, handler):
         # Keep these ordered as LIFO
         self._handlers.insert(0, (scheme, handler))
+
+    def register_entry_points(self):
+        # Load handlers provided by other packages
+        for entrypoint in entrypoints.get_group_all("papermill.handlers"):
+            self.register(entrypoint.name, entrypoint.load())
 
     def get_handler(self, path):
         local_handler = None
@@ -215,6 +222,7 @@ papermill_io.register("adl://", ADLHandler)
 papermill_io.register("abs://", ABSHandler)
 papermill_io.register("http://", HttpHandler)
 papermill_io.register("https://", HttpHandler)
+papermill_io.register_entry_points()
 
 
 def read_yaml_file(path):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -80,7 +80,7 @@ class PapermillIO(object):
 
     def register_entry_points(self):
         # Load handlers provided by other packages
-        for entrypoint in entrypoints.get_group_all("papermill.handlers"):
+        for entrypoint in entrypoints.get_group_all("papermill.io"):
             self.register(entrypoint.name, entrypoint.load())
 
     def get_handler(self, path):

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -8,7 +8,7 @@ from nbformat.notebooknode import NotebookNode
 
 from . import get_notebook_path
 
-from .. import engines
+from .. import engines, exceptions
 from ..log import logger
 from ..iorw import load_notebook_node
 from ..engines import NotebookExecutionManager, Engine, NBConvertEngine
@@ -496,3 +496,40 @@ class TestNBConvertEngine(unittest.TestCase):
                     )
                     info_mock.is_not_called()
                     warning_mock.is_not_called()
+
+
+class TestEngineRegistration(unittest.TestCase):
+    def setUp(self):
+        self.papermill_engines = engines.PapermillEngines()
+
+    def test_registration(self):
+        mock_engine = Mock()
+        self.papermill_engines.register("mock_engine", mock_engine)
+        self.assertIn("mock_engine", self.papermill_engines._engines)
+        self.assertIs(mock_engine, self.papermill_engines._engines["mock_engine"])
+
+    def test_getting(self):
+        mock_engine = Mock()
+        self.papermill_engines.register("mock_engine", mock_engine)
+        # test retrieving an engine works
+        retrieved_engine = self.papermill_engines.get_engine("mock_engine")
+        self.assertIs(mock_engine, retrieved_engine)
+        # test you can't retrieve a non-registered engine
+        self.assertRaises(
+            exceptions.PapermillException, self.papermill_engines.get_engine, "non-existent"
+        )
+
+    def test_registering_entry_points(self):
+        fake_entrypoint = Mock(load=Mock())
+        fake_entrypoint.name = "fake-engine"
+
+        # patcher =
+        with patch(
+            "entrypoints.get_group_all", return_value=[fake_entrypoint]
+        ) as mock_get_group_all:
+
+            self.papermill_engines.register_entry_points()
+            mock_get_group_all.assert_called_once_with("papermill.engine")
+            self.assertEqual(
+                self.papermill_engines.get_engine("fake-engine"), fake_entrypoint.load.return_value
+            )

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -523,7 +523,6 @@ class TestEngineRegistration(unittest.TestCase):
         fake_entrypoint = Mock(load=Mock())
         fake_entrypoint.name = "fake-engine"
 
-        # patcher =
         with patch(
             "entrypoints.get_group_all", return_value=[fake_entrypoint]
         ) as mock_get_group_all:

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -22,7 +22,6 @@ from ..exceptions import PapermillException
 from ..iorw import HttpHandler, LocalHandler, ADLHandler, PapermillIO
 
 FIXTURE_PATH = os.path.join(os.path.dirname(__file__), 'fixtures')
-SAMPLE_PACKAGE = samples_dir = os.path.join(os.path.dirname(__file__), 'entrypointpackage')
 
 
 class TestPapermillIO(unittest.TestCase):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -22,6 +22,7 @@ from ..exceptions import PapermillException
 from ..iorw import HttpHandler, LocalHandler, ADLHandler, PapermillIO
 
 FIXTURE_PATH = os.path.join(os.path.dirname(__file__), 'fixtures')
+SAMPLE_PACKAGE = samples_dir = os.path.join(os.path.dirname(__file__), 'entrypointpackage')
 
 
 class TestPapermillIO(unittest.TestCase):
@@ -60,6 +61,25 @@ class TestPapermillIO(unittest.TestCase):
 
         self.papermill_io.register("local", self.fake2)
         self.assertEqual(self.papermill_io.get_handler("dne"), self.fake2)
+
+    def test_entrypoint_register(self):
+
+        fake_entrypoint = Mock(load=Mock())
+        fake_entrypoint.name = "fake-from-entry-point://"
+
+        # patcher =
+        with patch(
+            "entrypoints.get_group_all", return_value=[fake_entrypoint]
+        ) as mock_get_group_all:
+
+            self.papermill_io.register_entry_points()
+            for scheme, handler in self.papermill_io._handlers:
+                print(scheme, handler)
+            mock_get_group_all.assert_called_once_with("papermill.handlers")
+            assert (
+                self.papermill_io.get_handler("fake-from-entry-point://")
+                == fake_entrypoint.load.return_value
+            )
 
     def test_register_ordering(self):
         # Should match fake1 with fake2 path

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -74,7 +74,7 @@ class TestPapermillIO(unittest.TestCase):
             self.papermill_io.register_entry_points()
             for scheme, handler in self.papermill_io._handlers:
                 print(scheme, handler)
-            mock_get_group_all.assert_called_once_with("papermill.handlers")
+            mock_get_group_all.assert_called_once_with("papermill.io")
             assert (
                 self.papermill_io.get_handler("fake-from-entry-point://")
                 == fake_entrypoint.load.return_value

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -66,7 +66,6 @@ class TestPapermillIO(unittest.TestCase):
         fake_entrypoint = Mock(load=Mock())
         fake_entrypoint.name = "fake-from-entry-point://"
 
-        # patcher =
         with patch(
             "entrypoints.get_group_all", return_value=[fake_entrypoint]
         ) as mock_get_group_all:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pandas
 requests
 azure-datalake-store >= 0.0.30
 azure-storage-blob
+entrypoints


### PR DESCRIPTION
This PR implements loading of IO handlers via entry points. This allows a third-party developer to implement a handler for papermill and declare it in `setup.py` under entry points.

The aim is to allow an ecosystem of papermill read / write options. This would allow, for example, to write custom papermill publishing methods that integrate with an organisation's infrastructure, or for a third-party hosting service (e.g. [Digital Ocean Spaces](https://www.digitalocean.com/products/spaces/) ). I have had a lot of success writing custom output formats for [RMarkdown](https://rmarkdown.rstudio.com/), and think allowing this for papermill would be a great feature.

The design of this implementation is inspired by `flake8`.

Effectively, what someone could do is define a package like this:

```
custom-papermill
| - setup.py
|- custom_papermill
    |- __init__.py
```

In `custom_papermill/__init__.py`, you could define a handler like this:

```python
# __init__.py

class CustomHandler(object):
    @classmethod
    def read(cls, path):
        return retrieve_custom_path(path)

    @classmethod
    def listdir(cls, path):
        raise PapermillException('listdir is not supported by CustomHandler')

    @classmethod
    def write(cls, buf, path):
        write_to_custom_path(buf, path)

    @classmethod
    def pretty_path(cls, path):
        return path
```

Then, in setup.py:

```python
# setup.py
from setuptools import setup, find_packages

setup(
    name = 'custom-papermill',
    version = '1.0.0',
    url = '',
    author = 'Author Name',
    author_email = 'author@gmail.com’,
    description = 'Description of my package',
    packages = find_packages(),
    install_requires = [],
    entry_points={
        "papermill.handlers": "customprotocol://=custom_papermill:CustomHandler"
    }
)
```

Then if a user has `custom_papermill` installed, a call like `papermill my_notebook.ipynb customprotocol://my_notebook.ipynb` will use the custom handler as defined in the custom_papermill package.

Outstanding on this:

- decide on the entry point group name (currently `papermill.handlers`, but can be changed)
- document how to create custom papermill entry points

I'm copying @zblz and @liamcoatman in on this as I've discussed this with them (we are interested in this as part of the platform SherlockML, which has a [report feature](https://docs.sherlockml.com/user-guide/reports.html).