### PR TITLE
Add support for executing notebooks in a different directory

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -74,6 +74,7 @@ def print_papermill_version(ctx, param, value):
     help="Flag for outputting the notebook without execution, but with parameters applied.",
 )
 @click.option('--kernel', '-k', help='Name of kernel to run.')
+@click.option('--cwd', default=None, help='Working directory to run notebook in.')
 @click.option(
     '--progress-bar/--no-progress-bar', default=None, help="Flag for turning on the progress bar."
 )
@@ -108,6 +109,7 @@ def papermill(
     engine,
     prepare_only,
     kernel,
+    cwd,
     progress_bar,
     log_output,
     start_timeout,
@@ -153,6 +155,7 @@ def papermill(
         log_output=log_output,
         start_timeout=start_timeout,
         report_mode=report_mode,
+        cwd=cwd,
     )
 
 

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -303,22 +303,6 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
-        )
-
-    @patch(cli.__name__ + '.execute_notebook')
-    def test_prepare_only(self, execute_patch):
-        self.runner.invoke(papermill, self.default_args + ['--prepare-only'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            prepare_only=True,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
             cwd=None,
         )
 
@@ -455,22 +439,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=123,
             report_mode=False,
-        )
-
-    @patch(cli.__name__ + '.execute_notebook')
-    def test_report_mode(self, execute_patch):
-        self.runner.invoke(papermill, self.default_args + ['--report-mode'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=123,
-            report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -94,6 +94,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -112,6 +113,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -133,6 +135,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -152,6 +155,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -172,6 +176,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -198,6 +203,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -333,6 +339,24 @@ class TestCLI(unittest.TestCase):
         )
 
     @patch(cli.__name__ + '.execute_notebook')
+    def test_set_cwd(self, execute_patch):
+        self.runner.invoke(papermill,
+                           self.default_args + ['--cwd', 'a/path/here'])
+        execute_patch.assert_called_with(
+            'input.ipynb',
+            'output.ipynb',
+            {},
+            engine_name=None,
+            prepare_only=False,
+            kernel_name=None,
+            log_output=False,
+            progress_bar=True,
+            start_timeout=60,
+            report_mode=False,
+            cwd='a/path/here',
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_progress_bar(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--progress-bar'])
         execute_patch.assert_called_with(
@@ -346,6 +370,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -362,6 +387,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=False,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -378,6 +404,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=False,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -394,6 +421,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -410,6 +438,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -458,6 +487,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=True,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -474,6 +504,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -528,6 +559,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=False,
             start_timeout=321,
             report_mode=True,
+            cwd=None,
         )
 
 

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -320,6 +320,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -218,6 +218,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -238,6 +239,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -261,6 +263,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -277,6 +280,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -309,6 +313,7 @@ class TestCLI(unittest.TestCase):
             progress_bar=True,
             start_timeout=60,
             report_mode=False,
+            cwd=None,
         )
 
     @patch(cli.__name__ + '.execute_notebook')

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -1,7 +1,9 @@
+import os
+
 import pytest
 import six
 
-from ..utils import retry
+from ..utils import retry, chdir
 
 if six.PY3:
     from unittest.mock import Mock, call
@@ -15,3 +17,13 @@ def test_retry():
     with pytest.raises(RuntimeError):
         wrapped_m("foo")
     m.assert_has_calls([call("foo"), call("foo"), call("foo")])
+
+
+def test_chdir():
+    old_cwd = os.getcwd()
+
+    with chdir('/tmp'):
+        assert os.getcwd() != old_cwd
+        assert os.getcwd() == '/tmp'
+
+    assert os.getcwd() == old_cwd

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -1,5 +1,7 @@
 import logging
+import os
 
+from contextlib import contextmanager
 from functools import wraps
 
 
@@ -25,3 +27,21 @@ def retry(num):
         return wrapper
 
     return decorate
+
+
+@contextmanager
+def chdir(path):
+    """Change working directory to `path` and restore old path on exit.
+
+    `path` can be `None` in which case this is a no-op.
+    """
+    if path is None:
+        yield
+
+    else:
+        old_dir = os.getcwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(old_dir)


### PR DESCRIPTION
This adds support for executing a notebook in a different working directory. This seems nicer than having to do `(cd some/where && papermill input.ipynb out.ipynb)` or `os.chdir('some/where')` before calling `pm.execute_notebook()`.

It lets you run `papermill --cwd some/where input.ipynb out.ipynb`. `cwd` seems a bit weird as name but it is what Python's `subprocess` uses to name the argument to set the current working directory for new processes so I stuck with it.

Generally useful? If yes I'll add tests.

Created as part of work for https://www.colorado.edu/earthlab/ 🎉 