### PR TITLE
Report mode fix for Jupyterlab

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -113,6 +113,7 @@ def parameterize_notebook(nb, kernel_name, parameters, report_mode=False):
     newcell.metadata['tags'] = ['injected-parameters']
 
     if report_mode:
+        newcell.metadata['jupyter'] = newcell.get('jupyter', {})
         newcell.metadata['jupyter']['source_hidden'] = True
 
     param_cell_index = _find_first_tagged_cell_index(nb, 'parameters')

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -205,7 +205,7 @@ class TestReportMode(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_report_mode(self):
-        nb = execute_notebook(self.notebook_path, self.nb_test_executed_fname, report_mode=True)
+        nb = execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'a': 0}, report_mode=True)
         for cell in nb.cells:
             if cell.cell_type == 'code':
                 self.assertEqual(cell.metadata.get('jupyter', {}).get('source_hidden'), True)

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -205,7 +205,9 @@ class TestReportMode(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_report_mode(self):
-        nb = execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'a': 0}, report_mode=True)
+        nb = execute_notebook(
+            self.notebook_path, self.nb_test_executed_fname, {'a': 0}, report_mode=True
+        )
         for cell in nb.cells:
             if cell.cell_type == 'code':
                 self.assertEqual(cell.metadata.get('jupyter', {}).get('source_hidden'), True)


### PR DESCRIPTION
Jupyterlab has no 'jupyter' field in cell metadata, so the code was crashing when it tried to run 

`newcell.metadata['jupyter']['source_hidden'] = True`

in report mode. I added 

`newcell.metadata['jupyter'] = newcell.get('jupyter', {})` 

before this line to fix the issue.