### PR TITLE
fix adl handler listdir not including adl:// scheme in returned paths

### DIFF
--- a/papermill/adl.py
+++ b/papermill/adl.py
@@ -25,7 +25,12 @@ class ADL(object):
     def listdir(self, url):
         (store_name, path) = self._split_url(url)
         adapter = self._create_adapter(store_name)
-        return adapter.ls(path)
+        return [
+            "adl://{store_name}.azuredatalakestore.net/{path_to_child}".format(
+                store_name=store_name, path_to_child=path_to_child
+            )
+            for path_to_child in adapter.ls(path)
+        ]
 
     def read(self, url):
         (store_name, path) = self._split_url(url)

--- a/papermill/tests/test_adl.py
+++ b/papermill/tests/test_adl.py
@@ -15,7 +15,9 @@ class ADLTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.ls = Mock(return_value=["foo", "bar", "baz"])
+        self.ls = Mock(
+            return_value=["path/to/directory/foo", "path/to/directory/bar", "path/to/directory/baz"]
+        )
         self.fakeFile = MagicMock()
         self.fakeFile.__iter__.return_value = [b"a", b"b", b"c"]
         self.fakeFile.__enter__.return_value = self.fakeFile
@@ -36,10 +38,14 @@ class ADLTest(unittest.TestCase):
 
     def test_listdir_calls_ls_on_adl_adapter(self):
         self.assertEqual(
-            self.adl.listdir("adl://foo_store.azuredatalakestore.net/path/to/file"),
-            ["foo", "bar", "baz"],
+            self.adl.listdir("adl://foo_store.azuredatalakestore.net/path/to/directory"),
+            [
+                "adl://foo_store.azuredatalakestore.net/path/to/directory/foo",
+                "adl://foo_store.azuredatalakestore.net/path/to/directory/bar",
+                "adl://foo_store.azuredatalakestore.net/path/to/directory/baz",
+            ],
         )
-        self.ls.assert_called_once_with("path/to/file")
+        self.ls.assert_called_once_with("path/to/directory")
 
     def test_read_opens_and_reads_file(self):
         self.assertEquals(


### PR DESCRIPTION
Calling listdir on the ADL handler with a path such as `adl://my_store.azuredatalakestore.net/path/to/directory` would previously return a list of paths without the `adl://my_store.azuredatalakestore.net/` prefix. Example: `["path/to/directory/foo", "path/to/directory/bar"]`

This would cause problems when the paths were later fed back to PapermillIO (for example, when reading the listed files), as they would be assumed to be local paths and the LocalHandler would be used.

Calling read_notebooks with an adl:// path sufficed to reproduce the issue.

With this PR, the paths returned by the ADL handler are full paths, with the adl:// scheme and store name.