### PR TITLE
Add Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ install:
   - pip install tox
 script:
   - tox -e $TOXENV
-  - touch .coverage
-  - mv .coverage $TRAVIS_BUILD_DIR/.coverage
 after_success:
   - coverage xml -i
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      # Try removing the google-compute-engine when this doesn't require sudo
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
       env: TOXENV=py37
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - pip install tox
 script:
   - tox -e $TOXENV
+  - touch .coverage
   - mv .coverage $TRAVIS_BUILD_DIR/.coverage
 after_success:
   - coverage xml -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,29 @@
 language: python
 sudo: false
-python:
-  - 2.7
-  - 3.5
-  - 3.6
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       # Try removing the google-compute-engine when this doesn't require sudo
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-# For some reason the pytest.ini isn't being respected
-env:
-  global:
-    - AWS_ACCESS_KEY_ID=foobar_key
-    - AWS_SECRET_ACCESS_KEY=foobar_secret
+      env: TOXENV=py37
+    - python: 3.6
+      env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=dist
+    - python: 3.6
+      env: TOXENV=manifest
 install:
-  - pip install setuptools pip --upgrade
-  - pip install -e .[test]
-  - pip install check-manifest flake8
-  # Needed for python 3.7 on travis to import boto because there's a partial package in the root site packages
-  - pip install google-compute-engine
-  - python -m ipykernel install --user
-before_script:
-  - flake8 . --count --ignore=E203,E731,F811,W503 --max-complexity=23 --max-line-length=104 --show-source --statistics
+  - pip install tox
 script:
-  # cd so we test the install, not the repo
-  - check-manifest
-  - cd `mktemp -d`
-  - pytest -v --maxfail=2 --cov=papermill --pyargs papermill -W always
+  - tox -e $TOXENV
   - mv .coverage $TRAVIS_BUILD_DIR/.coverage
-  - cd $TRAVIS_BUILD_DIR
-  - python setup.py sdist bdist_wheel
-  - python -m pip install -U --force-reinstall dist/papermill*.whl
-  - python -m pip install -U --force-reinstall --no-deps dist/papermill*.tar.gz
 after_success:
   - coverage xml -i
   - codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ For a full test suite of all envs and linting checks simply run tox without any 
 ```
 tox
 ```
-This will require python2.7, python3.6, and python3.7 to be installed. **Note** that python 3.7 has problems with the alpha build which is the available package version on many linux distros. Local build failures with 3.7 can happen as a result (you'll see a seg fault or exist code -11).
+This will require python2.7, python3.5, python3.6, and python3.7 to be installed. **Note** that python 3.7 has problems with the alpha build which is the available package version on many linux distros. Local build failures with 3.7 can happen as a result (you'll see a seg fault or exist code -11).
 
 Alternavitely pytest can be used if you have an environment already setup which works or has custom packages not present in the tox build.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,20 @@ _Note: When you are finished you can use `source deactivate` to go back to your 
 ### Running Tests Locally
 
 We need to install the development package before we can run the tests. If anything is confusing below, always resort to the relevant documentation.
+
+For the most basic test runs against python 3.6 use this tox subset (callable after `pip install tox`):
+```
+tox -e py36
+```
+This will just execute the unittests against python 3.6 in a new virtual env. The first run will take longer to setup the virtualenv, but will be fast after that point.
+
+For a full test suite of all envs and linting checks simply run tox without any arguments
+```
+tox
+```
+This will require python2.7, python3.6, and python3.7 to be installed. **Note** that python 3.7 has problems with the alpha build which is the available package version on many linux distros. Local build failures with 3.7 can happen as a result (you'll see a seg fault or exist code -11).
+
+Alternavitely pytest can be used if you have an environment already setup which works or has custom packages not present in the tox build.
 ```
 pytest --pyargs papermill
 ```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include papermill *.txt
 include setup.py
 include requirements.txt
 include requirements-dev.txt
+include tox.ini
 include pytest.ini
 include README.rst
 include LICENSE

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ botocore
 ipywidgets
 flake8
 tox
+google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ boto3
 botocore
 ipywidgets
 flake8
+tox

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ def read(fname):
         return fhandle.read()
 
 
-req_path = os.path.join(os.path.dirname('__file__'), 'requirements.txt')
+req_path = os.path.join(os.path.dirname(__file__), 'requirements.txt')
 required = [req.strip() for req in read(req_path).splitlines() if req.strip()]
 
-test_req_path = os.path.join(os.path.dirname('__file__'), 'requirements-dev.txt')
+test_req_path = os.path.join(os.path.dirname(__file__), 'requirements-dev.txt')
 test_required = [req.strip() for req in read(test_req_path).splitlines() if req.strip()]
 extras_require = {"test": test_required, "dev": test_required}
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ setenv =
 passenv = *
 basepython =
     py27: python2.7
+    py35: python3.5
     py36: python3.6
     py37: python3.7
     flake8: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py{27,36,37}, flake8, dist, manifest
+envlist = py{27,35,36,37}, flake8, dist, manifest
 
 # Linters
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+skipsdist = true
+envlist = py{27,36,37}, flake8, dist, manifest
+
+# Linters
+[testenv:flake8]
+skip_install = true
+deps = flake8
+commands = flake8 papermill --count --ignore=E203,E731,F811,W503 --max-complexity=23 --max-line-length=104 --show-source --statistics
+
+# Manifest
+[testenv:manifest]
+skip_install = true
+deps = check-manifest
+commands = check-manifest
+
+# Distro
+[testenv:dist]
+skip_install = true
+deps =
+# Have to use /bin/bash or the `*` will cause that argument to get quoted by the tox command line...
+commands =
+    python setup.py sdist --dist-dir={distdir} bdist_wheel --dist-dir={distdir}
+    /bin/bash -c 'python -m pip install -U --force-reinstall {distdir}/papermill*.whl'
+    /bin/bash -c 'python -m pip install -U --force-reinstall --no-deps {distdir}/papermill*.tar.gz'
+
+[testenv]
+# disable Python's hash randomization for tests that stringify dicts, etc
+setenv =
+    PYTHONHASHSEED = 0
+    AWS_ACCESS_KEY_ID=foobar_key
+    AWS_SECRET_ACCESS_KEY=foobar_secret
+passenv = *
+basepython =
+    py27: python2.7
+    py36: python3.6
+    py37: python3.7
+    flake8: python3.6
+    manifest: python3.6
+    dist: python3.6
+deps =
+    -r requirements.txt
+    -r requirements-dev.txt
+commands = pytest -v --maxfail=2 --cov=papermill -W always


### PR DESCRIPTION
Addresses https://github.com/nteract/papermill/issues/227 so our builds and local development use the same test calls. Also helps separate manifest and linting errors from the unit testing paths so it's clearer what failed when there's such an issue.

Had some trouble with py37 seg faulting on my local machine. But I think this is a ubuntu 17.10 issue as it only bundles an alpha build of py37 from 2017 :/