### PR TITLE
update requirements.txt to pin tqdm version >= 4.29.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyyaml
 nbformat
 nbconvert >= 5.4
 six
-tqdm
+tqdm >= 4.29.1
 jupyter_client
 pandas
 requests


### PR DESCRIPTION
per #287 - tqdm.auto didn't exist in 4.19.4, and perhaps later versions, but it does in 4.29.1.

thx @betatim for [suggestion](https://twitter.com/betatim/status/1087020834827522048) to go the extra inch :)
