### PR TITLE
Add None translation

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -31,6 +31,7 @@ else:
         (-5432.1, '-5432.1'),
         (True, 'True'),
         (False, 'False'),
+        (None, 'None'),
     ],
 )
 def test_translate_type_python(test_input, expected):
@@ -83,6 +84,7 @@ def test_translate_comment_python(test_input, expected):
         (-5432.1, '-5432.1'),
         (True, 'TRUE'),
         (False, 'FALSE'),
+        (None, 'NULL'),
     ],
 )
 def test_translate_type_r(test_input, expected):
@@ -137,6 +139,7 @@ def test_translate_codify_r(parameters, expected):
         (-2147483649, '-2147483649L'),
         (True, 'true'),
         (False, 'false'),
+        (None, 'None'),
     ],
 )
 def test_translate_type_scala(test_input, expected):
@@ -202,6 +205,7 @@ def test_translate_codify_scala(parameters, expected):
         (-5432.1, '-5432.1'),
         (True, 'true'),
         (False, 'false'),
+        (None, 'nothing'),
     ],
 )
 def test_translate_type_julia(test_input, expected):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -50,6 +50,11 @@ class Translator(object):
         return cls.translate_escaped_str(val)
 
     @classmethod
+    def translate_none(cls, val):
+        """Default behavior for translation"""
+        return cls.translate_raw_str(val)
+
+    @classmethod
     def translate_int(cls, val):
         """Default behavior for translation"""
         return cls.translate_raw_str(val)
@@ -75,7 +80,9 @@ class Translator(object):
     @classmethod
     def translate(cls, val):
         """Translate each of the standard json/yaml types to appropiate objects."""
-        if isinstance(val, string_types):
+        if val is None:
+            return cls.translate_none(val)
+        elif isinstance(val, string_types):
             return cls.translate_str(val)
         # Needs to be before integer checks
         elif isinstance(val, bool):
@@ -131,6 +138,10 @@ class PythonTranslator(Translator):
 
 class RTranslator(Translator):
     @classmethod
+    def translate_none(cls, val):
+        return 'NULL'
+
+    @classmethod
     def translate_bool(cls, val):
         return 'TRUE' if val else 'FALSE'
 
@@ -181,6 +192,10 @@ class ScalaTranslator(Translator):
 
 
 class JuliaTranslator(Translator):
+    @classmethod
+    def translate_none(cls, val):
+        return 'nothing'
+
     @classmethod
     def translate_dict(cls, val):
         escaped = ', '.join(


### PR DESCRIPTION
This PR adds `None` translation method to `Translator` class.

When I try to pass `None` through papermill,
it's translated into `"None"` string object because `translate_escaped_str` method is called.

I think that `None` should be translated into `None` in Python notebook.