### PR TITLE
add tox doc build to ease local doc builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,13 @@ deps =
     -r requirements.txt
     -r requirements-dev.txt
 commands = pytest -v --maxfail=2 --cov=papermill -W always
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+basepython = python3.7
+deps =
+    -r docs/requirements-doc.txt
+extras = docs
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+


### PR DESCRIPTION
Should be merged after #292.

Docs can now be built locally by entering `tox -e docs`.