### PR TITLE
Add GCS handler

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -224,30 +224,26 @@ class ABSHandler(object):
 
 
 class GCSHandler(object):
-    _client = None
+    def __init__(self):
+        self._client = None
 
-    @classmethod
-    def _get_client(cls):
-        if cls._client is None:
-            cls._client = gcsfs.GCSFileSystem()
-        return cls._client
+    def _get_client(self):
+        if self._client is None:
+            self._client = gcsfs.GCSFileSystem()
+        return self._client
 
-    @classmethod
-    def read(cls, path):
-        with cls._get_client().open(path) as f:
+    def read(self, path):
+        with self._get_client().open(path) as f:
             return f.read()
 
-    @classmethod
-    def listdir(cls, path):
-        return cls._get_client().ls(path)
+    def listdir(self, path):
+        return self._get_client().ls(path)
 
-    @classmethod
-    def write(cls, buf, path):
-        with cls._get_client().open(path, 'w') as f:
+    def write(self, buf, path):
+        with self._get_client().open(path, 'w') as f:
             return f.write(buf)
 
-    @classmethod
-    def pretty_path(cls, path):
+    def pretty_path(self, path):
         return path
 
 
@@ -259,8 +255,9 @@ papermill_io.register("adl://", ADLHandler)
 papermill_io.register("abs://", ABSHandler)
 papermill_io.register("http://", HttpHandler)
 papermill_io.register("https://", HttpHandler)
-papermill_io.register("gcs://", GCSHandler)
-papermill_io.register("gs://", GCSHandler)
+gcs_handler = GCSHandler()
+papermill_io.register("gcs://", gcs_handler)
+papermill_io.register("gs://", gcs_handler)
 papermill_io.register_entry_points()
 
 

--- a/papermill/tests/test_gcs.py
+++ b/papermill/tests/test_gcs.py
@@ -1,0 +1,57 @@
+from papermill.iorw import GCSHandler
+
+
+class MockGCSFileSystem(object):
+    def __init__(self):
+        self._file = MockGCSFile()
+
+    def open(self, *args, **kwargs):
+        return self._file
+
+    def ls(self, *args, **kwargs):
+        return []
+
+
+class MockGCSFile(object):
+    def __enter__(self):
+        self._value = 'default value'
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def read(self):
+        return self._value
+
+    def write(self, data):
+        pass
+
+
+def test_gcs_read(mocker):
+    mocker.patch('gcsfs.GCSFileSystem', MockGCSFileSystem)
+    gcs_handler = GCSHandler()
+    client = gcs_handler._get_client()
+    assert gcs_handler.read('gs://bucket/test.ipynb') == 'default value'
+
+    # Check that client is only generated once
+    assert client is gcs_handler._get_client()
+
+
+def test_gcs_write(mocker):
+    mocker.patch('gcsfs.GCSFileSystem', MockGCSFileSystem)
+    gcs_handler = GCSHandler()
+    client = gcs_handler._get_client()
+    gcs_handler.write('new value', 'gs://bucket/test.ipynb')
+
+    # Check that client is only generated once
+    assert client is gcs_handler._get_client()
+
+
+def test_gcs_listdir(mocker):
+    mocker.patch('gcsfs.GCSFileSystem', MockGCSFileSystem)
+    gcs_handler = GCSHandler()
+    client = gcs_handler._get_client()
+    gcs_handler.listdir('testdir')
+
+    # Check that client is only generated once
+    assert client is gcs_handler._get_client()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,3 @@ ipywidgets
 flake8
 tox
 google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
-gcsfs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ ipywidgets
 flake8
 tox
 google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
+gcsfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ requests
 azure-datalake-store >= 0.0.30
 azure-storage-blob
 entrypoints
+gcsfs


### PR DESCRIPTION
Fixes #213. This looks like all that's needed but I'm not sure what to do about testing. It seems like the S3/Azure functionality is all basically implementing stuff that's already part of `gcsfs`, hence the simplicity of this logic; I'm not sure that tests like those in `test_s3` and `test_abs` would really be doing anything...