### PR TITLE
Update README.md to include supported Handlers. Minor iorw cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Papermill supports the following name handlers for input and output paths during
 
  * Azure: [Azure DataLake Store](https://docs.microsoft.com/en-us/azure/data-lake-store/data-lake-store-overview), [Azure Blob Store](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview) `adl://, abs://`
     
- * Google Cloud: [Google Cloud Storage](https://cloud.google.com/storage/) `gcs://, gs://`
+ * Google Cloud: [Google Cloud Storage](https://cloud.google.com/storage/) `gs://`
 
 Python In-notebook Bindings
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ linear_function:
     intercept: 1.0"
 ```
 
+#### Supported Name Handlers
+
+Papermill supports the following name handlers for input and output paths during execution: 
+
+ * Local file system: `local`
+
+ * HTTP, HTTPS protocol:  `http://, https://`
+
+ * Amazon Web Services: [AWS S3](https://aws.amazon.com/s3/) `s3://`
+
+ * Azure: [Azure DataLake Store](https://docs.microsoft.com/en-us/azure/data-lake-store/data-lake-store-overview), [Azure Blob Store](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview) `adl://, abs://`
+    
+ * Google Cloud: [Google Cloud Storage](https://cloud.google.com/storage/) `gcs://, gs://`
+
 Python In-notebook Bindings
 ---------------------------
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -255,9 +255,8 @@ papermill_io.register("adl://", ADLHandler)
 papermill_io.register("abs://", ABSHandler)
 papermill_io.register("http://", HttpHandler)
 papermill_io.register("https://", HttpHandler)
-gcs_handler = GCSHandler()
-papermill_io.register("gcs://", gcs_handler)
-papermill_io.register("gs://", gcs_handler)
+papermill_io.register("gcs://", GCSHandler())
+papermill_io.register("gs://", GCSHandler())
 papermill_io.register_entry_points()
 
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -255,7 +255,6 @@ papermill_io.register("adl://", ADLHandler)
 papermill_io.register("abs://", ABSHandler)
 papermill_io.register("http://", HttpHandler)
 papermill_io.register("https://", HttpHandler)
-papermill_io.register("gcs://", GCSHandler())
 papermill_io.register("gs://", GCSHandler())
 papermill_io.register_entry_points()
 


### PR DESCRIPTION
- Update README.md to include supported name handlers.
- Minor cleanup in iorw.py to conform to previous style during instantiation of PapermillIO.