### PR TITLE
Handle 429 Errors

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -11,6 +11,7 @@ import nbformat
 import requests
 import warnings
 import entrypoints
+import retry
 
 from contextlib import contextmanager
 
@@ -46,6 +47,11 @@ try:
     from gcsfs import GCSFileSystem
 except ImportError:
     GCSFileSystem = missing_dependency_generator("gcsfs", "gcs")
+
+try:
+    from gcsfs.utils import HtmlError as RateLimitException
+except ImportError:
+    RateLimitException = Exception
 
 try:
     FileNotFoundError
@@ -255,6 +261,7 @@ class GCSHandler(object):
     def listdir(self, path):
         return self._get_client().ls(path)
 
+    @retry.retry(RateLimitException, delay=1, backoff=2, max_delay=4)
     def write(self, buf, path):
         with self._get_client().open(path, 'w') as f:
             return f.write(buf)

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -261,7 +261,7 @@ class GCSHandler(object):
     def listdir(self, path):
         return self._get_client().ls(path)
 
-    @retry.retry(RateLimitException, delay=1, backoff=2, max_delay=4)
+    @retry.retry(RateLimitException, tries=3, delay=1, backoff=2, max_delay=4)
     def write(self, buf, path):
         with self._get_client().open(path, 'w') as f:
             return f.write(buf)

--- a/papermill/tests/test_gcs.py
+++ b/papermill/tests/test_gcs.py
@@ -1,75 +1,103 @@
+import six
+import unittest
+from retry.api import retry_call
+from gcsfs.utils import HtmlError as RateLimitException
 from ..iorw import GCSHandler
 
+if six.PY3:
+  from unittest.mock import patch
+else:
+  from mock import patch
 
-class RetryableError(Exception):
-    pass
+_RETRIES = 3
 
 
 class MockGCSFileSystem(object):
-    def __init__(self):
-        self._file = MockGCSFile()
+  def __init__(self):
+    self._file = MockGCSFile()
 
-    def open(self, *args, **kwargs):
-        return self._file
+  def open(self, *args, **kwargs):
+    return self._file
 
-    def ls(self, *args, **kwargs):
-        return []
+  def ls(self, *args, **kwargs):
+    return []
 
 
 class MockGCSFile(object):
-    def __enter__(self):
-        self._value = 'default value'
-        return self
 
-    def __exit__(self, *args, **kwargs):
-        pass
+  def __init__(self):
+    self.write_count = 0
 
-    def read(self):
-        return self._value
+  def __enter__(self):
+    self._value = 'default value'
+    return self
 
-    def write(self, buf):
-        if not buf:
-            raise RetryableError
+  def __exit__(self, *args, **kwargs):
+    pass
+
+  def read(self):
+    return self._value
+
+  def write(self, buf):
+    self.write_count += 1
+    if buf == 'raise_limit_exception':
+      raise RateLimitException
+    elif buf == 'retry':
+      if self.write_count < _RETRIES:
+        raise RateLimitException
+      else:
+        return self.write_count
+    else:
+      pass
 
 
-def test_gcs_read(mocker):
-    mocker.patch('papermill.iorw.GCSFileSystem', MockGCSFileSystem)
-    gcs_handler = GCSHandler()
-    client = gcs_handler._get_client()
-    assert gcs_handler.read('gs://bucket/test.ipynb') == 'default value'
+class GCSTest(unittest.TestCase):
+  """
+     Tests for `GCS`
+  """
 
+  def setUp(self):
+    self.gcs_handler = GCSHandler()
+
+  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+  def test_gcs_read(self, mock_gcs_filesystem):
+    client = self.gcs_handler._get_client()
+    assert self.gcs_handler.read('gs://bucket/test.ipynb') == 'default value'
     # Check that client is only generated once
-    assert client is gcs_handler._get_client()
+    self.assertIs(client, self.gcs_handler._get_client())
 
-
-def test_gcs_write(mocker):
-    mocker.patch('papermill.iorw.GCSFileSystem', MockGCSFileSystem)
-    gcs_handler = GCSHandler()
-    client = gcs_handler._get_client()
-    gcs_handler.write('new value', 'gs://bucket/test.ipynb')
+  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+  def test_gcs_write(self, mock_gcs_filesystem):
+    client = self.gcs_handler._get_client()
+    self.gcs_handler.write('new value', 'gs://bucket/test.ipynb')
     # Check that client is only generated once
-    assert client is gcs_handler._get_client()
+    self.assertIs(client, self.gcs_handler._get_client())
 
-
-def test_gcs_write_retry(mocker):
-    mocker.patch('papermill.iorw.GCSFileSystem', MockGCSFileSystem)
-    counter = 0
-    try:
-        gcs_handler = GCSHandler()
-        client = gcs_handler._get_client()
-        gcs_handler.write('', 'gs://bucket/test.ipynb')
-    except RetryableError:
-        counter += 1
-    assert counter == 1
+  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+  def test_gcs_listdir(self, mock_gcs_filesystem):
+    client = self.gcs_handler._get_client()
+    self.gcs_handler.listdir('testdir')
     # Check that client is only generated once
-    assert client is gcs_handler._get_client()
+    self.assertIs(client, self.gcs_handler._get_client())
 
+  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+  def test_gcs_handle_exception(self, mock_gcs_filesystem):
+    with self.assertRaises(RateLimitException):
+      retry_call(self.gcs_handler.write,
+                 exceptions=RateLimitException,
+                 fargs=['raise_limit_exception', 'gs://bucket/test.ipynb'],
+                 tries=_RETRIES,
+                 delay=1,
+                 backoff=1,
+                 max_delay=2)
 
-def test_gcs_listdir(mocker):
-    mocker.patch('papermill.iorw.GCSFileSystem', MockGCSFileSystem)
-    gcs_handler = GCSHandler()
-    client = gcs_handler._get_client()
-    gcs_handler.listdir('testdir')
-
-    # Check that client is only generated once
-    assert client is gcs_handler._get_client()
+  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+  def test_gcs_retry(self, mock_gcs_filesystem):
+    write_count = retry_call(self.gcs_handler.write,
+                             exceptions=RateLimitException,
+                             fargs=['retry', 'gs://bucket/test.ipynb'],
+                             tries=_RETRIES,
+                             delay=1,
+                             backoff=1,
+                             max_delay=2)
+    self.assertEqual(write_count, _RETRIES)

--- a/papermill/tests/test_gcs.py
+++ b/papermill/tests/test_gcs.py
@@ -1,103 +1,103 @@
-import six
 import unittest
-from retry.api import retry_call
 from gcsfs.utils import HtmlError as RateLimitException
 from ..iorw import GCSHandler
+from retry.api import retry_call
+import six
 
 if six.PY3:
-  from unittest.mock import patch
+    from unittest.mock import patch
 else:
-  from mock import patch
+    from mock import patch
 
 _RETRIES = 3
 
 
 class MockGCSFileSystem(object):
-  def __init__(self):
-    self._file = MockGCSFile()
+    def __init__(self):
+        self._file = MockGCSFile()
 
-  def open(self, *args, **kwargs):
-    return self._file
+    def open(self, *args, **kwargs):
+        return self._file
 
-  def ls(self, *args, **kwargs):
-    return []
+    def ls(self, *args, **kwargs):
+        return []
 
 
 class MockGCSFile(object):
+    def __init__(self):
+        self.write_count = 0
 
-  def __init__(self):
-    self.write_count = 0
+    def __enter__(self):
+        self._value = 'default value'
+        return self
 
-  def __enter__(self):
-    self._value = 'default value'
-    return self
+    def __exit__(self, *args, **kwargs):
+        pass
 
-  def __exit__(self, *args, **kwargs):
-    pass
+    def read(self):
+        return self._value
 
-  def read(self):
-    return self._value
-
-  def write(self, buf):
-    self.write_count += 1
-    if buf == 'raise_limit_exception':
-      raise RateLimitException
-    elif buf == 'retry':
-      if self.write_count < _RETRIES:
-        raise RateLimitException
-      else:
-        return self.write_count
-    else:
-      pass
+    def write(self, buf):
+        self.write_count += 1
+        if buf == 'raise_limit_exception':
+            raise RateLimitException
+        elif buf == 'retry':
+            if self.write_count < _RETRIES:
+                raise RateLimitException
+            else:
+                return self.write_count
+        else:
+            pass
 
 
 class GCSTest(unittest.TestCase):
-  """
-     Tests for `GCS`
-  """
+    """Tests for `GCS`."""
 
-  def setUp(self):
-    self.gcs_handler = GCSHandler()
+    def setUp(self):
+        self.gcs_handler = GCSHandler()
 
-  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
-  def test_gcs_read(self, mock_gcs_filesystem):
-    client = self.gcs_handler._get_client()
-    assert self.gcs_handler.read('gs://bucket/test.ipynb') == 'default value'
-    # Check that client is only generated once
-    self.assertIs(client, self.gcs_handler._get_client())
+    @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+    def test_gcs_read(self, mock_gcs_filesystem):
+        client = self.gcs_handler._get_client()
+        assert self.gcs_handler.read(
+            'gs://bucket/test.ipynb') == 'default value'
+        # Check that client is only generated once
+        self.assertIs(client, self.gcs_handler._get_client())
 
-  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
-  def test_gcs_write(self, mock_gcs_filesystem):
-    client = self.gcs_handler._get_client()
-    self.gcs_handler.write('new value', 'gs://bucket/test.ipynb')
-    # Check that client is only generated once
-    self.assertIs(client, self.gcs_handler._get_client())
+    @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+    def test_gcs_write(self, mock_gcs_filesystem):
+        client = self.gcs_handler._get_client()
+        self.gcs_handler.write('new value', 'gs://bucket/test.ipynb')
+        # Check that client is only generated once
+        self.assertIs(client, self.gcs_handler._get_client())
 
-  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
-  def test_gcs_listdir(self, mock_gcs_filesystem):
-    client = self.gcs_handler._get_client()
-    self.gcs_handler.listdir('testdir')
-    # Check that client is only generated once
-    self.assertIs(client, self.gcs_handler._get_client())
+    @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+    def test_gcs_listdir(self, mock_gcs_filesystem):
+        client = self.gcs_handler._get_client()
+        self.gcs_handler.listdir('testdir')
+        # Check that client is only generated once
+        self.assertIs(client, self.gcs_handler._get_client())
 
-  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
-  def test_gcs_handle_exception(self, mock_gcs_filesystem):
-    with self.assertRaises(RateLimitException):
-      retry_call(self.gcs_handler.write,
-                 exceptions=RateLimitException,
-                 fargs=['raise_limit_exception', 'gs://bucket/test.ipynb'],
-                 tries=_RETRIES,
-                 delay=1,
-                 backoff=1,
-                 max_delay=2)
+    @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+    def test_gcs_handle_exception(self, mock_gcs_filesystem):
+        with self.assertRaises(RateLimitException):
+            retry_call(
+                self.gcs_handler.write,
+                exceptions=RateLimitException,
+                fargs=['raise_limit_exception', 'gs://bucket/test.ipynb'],
+                tries=_RETRIES,
+                delay=1,
+                backoff=1,
+                max_delay=2)
 
-  @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
-  def test_gcs_retry(self, mock_gcs_filesystem):
-    write_count = retry_call(self.gcs_handler.write,
-                             exceptions=RateLimitException,
-                             fargs=['retry', 'gs://bucket/test.ipynb'],
-                             tries=_RETRIES,
-                             delay=1,
-                             backoff=1,
-                             max_delay=2)
-    self.assertEqual(write_count, _RETRIES)
+    @patch('papermill.iorw.GCSFileSystem', side_effect=MockGCSFileSystem)
+    def test_gcs_retry(self, mock_gcs_filesystem):
+        write_count = retry_call(
+            self.gcs_handler.write,
+            exceptions=RateLimitException,
+            fargs=['retry', 'gs://bucket/test.ipynb'],
+            tries=_RETRIES,
+            delay=1,
+            backoff=1,
+            max_delay=2)
+        self.assertEqual(write_count, _RETRIES)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ jupyter_client
 pandas
 requests
 entrypoints
-
+retry


### PR DESCRIPTION
Add retry library to be able to handle writes to GCS.
Currently papermill emits a save after each cell executes.