### PR TITLE
Replaced retry with tenacity library

### DIFF
--- a/papermill/tests/test_gcs.py
+++ b/papermill/tests/test_gcs.py
@@ -85,7 +85,7 @@ class GCSTest(unittest.TestCase):
     )
     def test_gcs_handle_exception(self, mock_gcs_filesystem):
         with patch.object(GCSHandler, 'RETRY_DELAY', 0):
-            with patch.object(GCSHandler, 'RETRY_BACKOFF', 0):
+            with patch.object(GCSHandler, 'RETRY_MULTIPLIER', 0):
                 with patch.object(GCSHandler, 'RETRY_MAX_DELAY', 0):
                     with self.assertRaises(PapermillRateLimitException):
                         self.gcs_handler.write('raise_limit_exception', 'gs://bucket/test.ipynb')
@@ -96,7 +96,7 @@ class GCSTest(unittest.TestCase):
     )
     def test_gcs_retry(self, mock_gcs_filesystem):
         with patch.object(GCSHandler, 'RETRY_DELAY', 0):
-            with patch.object(GCSHandler, 'RETRY_BACKOFF', 0):
+            with patch.object(GCSHandler, 'RETRY_MULTIPLIER', 0):
                 with patch.object(GCSHandler, 'RETRY_MAX_DELAY', 0):
                     self.assertEqual(
                         self.gcs_handler.write('raise_limit_exception', 'gs://bucket/test.ipynb'), 2
@@ -108,7 +108,7 @@ class GCSTest(unittest.TestCase):
     )
     def test_gcs_retry_older_exception(self, mock_gcs_filesystem):
         with patch.object(GCSHandler, 'RETRY_DELAY', 0):
-            with patch.object(GCSHandler, 'RETRY_BACKOFF', 0):
+            with patch.object(GCSHandler, 'RETRY_MULTIPLIER', 0):
                 with patch.object(GCSHandler, 'RETRY_MAX_DELAY', 0):
                     self.assertEqual(
                         self.gcs_handler.write('raise_limit_exception', 'gs://bucket/test.ipynb'), 2
@@ -120,7 +120,7 @@ class GCSTest(unittest.TestCase):
     )
     def test_gcs_retry_unknown_failure_code(self, mock_gcs_filesystem):
         with patch.object(GCSHandler, 'RETRY_DELAY', 0):
-            with patch.object(GCSHandler, 'RETRY_BACKOFF', 0):
+            with patch.object(GCSHandler, 'RETRY_MULTIPLIER', 0):
                 with patch.object(GCSHandler, 'RETRY_MAX_DELAY', 0):
                     self.assertEqual(
                         self.gcs_handler.write('raise_limit_exception', 'gs://bucket/test.ipynb'), 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ jupyter_client
 pandas
 requests
 entrypoints
-retry
+tenacity


### PR DESCRIPTION
The retry library is no longer being maintained, and is causing issues with conda builds. This should help unblock https://github.com/conda-forge/papermill-feedstock/pull/11