### PR TITLE
Added postBuild to fix pip install issues with pip 19

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# Work-around until pip stops making this broken in requirement.txt
+pip install -e . --no-use-pep517 --no-cache-dir

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,3 @@
--e .
 nteract-scrapbook
 matplotlib
 ipywidgets


### PR DESCRIPTION
Fixes https://github.com/nteract/papermill/issues/348

Tested against my branch at https://hub.mybinder.org/user/mseal-papermill-4d7pfjpg/notebooks/binder/cli-simple/cli_example.ipynb

See https://github.com/pypa/pip/issues/6433 for why this caused us problem with pip 19 upgrade.