### PR TITLE
remove unused pandas dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ ENV/
 # VSCode
 .vscode/
 
+# Visual Studio
+.vs/
+
 # pytest
 .pytest_cache
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,5 @@
 nteract-scrapbook
+pandas
 matplotlib
 ipywidgets
 ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ nbconvert >= 5.5
 six
 tqdm >= 4.29.1
 jupyter_client
-pandas
 requests
 entrypoints
 tenacity


### PR DESCRIPTION
- remove unused pandas dependency (leftover from 0.* versions)
- add .vs/ to .gitignore

* added pandas to binder requirements as it's referenced in a notebook even though it will be brought in as scrapbook dependency