### PR TITLE
pass through notebook engine arguments

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -358,7 +358,7 @@ class NBConvertEngine(Engine):
         # Rearrange arguments. Handle potential duplicates from **kwargs.
         # Prioritize values passed to the function or set in the module.
         preprocessor_handled_args = ['timeout', 'start_timeout', 'kernel_name', 'log']
-        safe_kwargs = {key: kwargs[key] for key in kwargs if key not in preprocessor_handled_args }
+        safe_kwargs = {key: kwargs[key] for key in kwargs if key not in preprocessor_handled_args}
         timeout = execution_timeout if execution_timeout else kwargs.get('timeout')
         preprocessor = PapermillExecutePreprocessor(
             timeout=timeout,

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -368,7 +368,7 @@ class NBConvertEngine(Engine):
             **safe_kwargs
         )
         preprocessor.log_output = log_output
-        preprocessor.preprocess(nb_man, kwargs)
+        preprocessor.preprocess(nb_man, safe_kwargs)
 
 
 # Instantiate a PapermillEngines instance, register Handlers and entrypoints

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -357,7 +357,7 @@ class NBConvertEngine(Engine):
         """
         # Rearrange arguments. Handle potential duplicates from **kwargs.
         # Prioritize values passed to the function or set in the module.
-        preprocessor_handled_args = ['timeout', 'start_timeout', 'kernel_name', 'log']
+        preprocessor_handled_args = ['timeout', 'startup_timeout', 'kernel_name', 'log']
         safe_kwargs = {key: kwargs[key] for key in kwargs if key not in preprocessor_handled_args}
         timeout = execution_timeout if execution_timeout else kwargs.get('timeout')
         preprocessor = PapermillExecutePreprocessor(

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -355,11 +355,17 @@ class NBConvertEngine(Engine):
         by `nbconvert`, and it is somewhat misleading here. The preprocesser
         represents a notebook processor, not a preparation object.
         """
+        # Rearrange arguments. Handle potential duplicates from **kwargs.
+        # Prioritize values passed to the function or set in the module.
+        preprocessor_handled_args = ['timeout', 'start_timeout', 'kernel_name', 'log']
+        safe_kwargs = {key: kwargs[key] for key in kwargs if key not in preprocessor_handled_args }
+        timeout = execution_timeout if execution_timeout else kwargs.get('timeout')
         preprocessor = PapermillExecutePreprocessor(
-            timeout=execution_timeout,
+            timeout=timeout,
             startup_timeout=start_timeout,
             kernel_name=kernel_name,
             log=logger,
+            **safe_kwargs
         )
         preprocessor.log_output = log_output
         preprocessor.preprocess(nb_man, kwargs)

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -25,6 +25,7 @@ def execute_notebook(
     start_timeout=60,
     report_mode=False,
     cwd=None,
+    **kwargs
 ):
     """Executes a single notebook locally.
 
@@ -52,6 +53,8 @@ def execute_notebook(
         Flag for whether or not to hide input.
     cwd : str, optional
         Working directory to use when executing the notebook
+    **kwargs
+        Arbitrary keyword arguments to pass to the notebook engine
 
     Returns
     -------
@@ -91,6 +94,7 @@ def execute_notebook(
                     progress_bar=progress_bar,
                     log_output=log_output,
                     start_timeout=start_timeout,
+                    **kwargs
                 )
 
             # Check for errors first (it saves on error before raising)

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -409,9 +409,14 @@ class TestNBConvertEngine(unittest.TestCase):
                 self.assertNotEqual(self.nb, nb)
 
                 pep_mock.assert_called_once()
-                pep_mock.assert_called_once_with(
-                    timeout=1000, startup_timeout=30, kernel_name='python', log=logger
-                )
+
+                args, kwargs = pep_mock.call_args
+                expected = [('timeout', 1000), ('startup_timeout', 30),
+                            ('kernel_name', 'python'), ('log', logger)]
+                actual = set([(key, kwargs[key]) for key in kwargs])
+                msg='Expected arguments {} are not a subset of actual {}'.format(expected, actual)
+                self.assertTrue(set(expected).issubset(actual), msg=msg)
+
                 log_out_mock.assert_called_once_with(True)
                 pep_mock.return_value.preprocess.assert_called_once_with(
                     AnyMock(NotebookExecutionManager), {'bar': 'baz'}

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -414,7 +414,7 @@ class TestNBConvertEngine(unittest.TestCase):
                 expected = [('timeout', 1000), ('startup_timeout', 30),
                             ('kernel_name', 'python'), ('log', logger)]
                 actual = set([(key, kwargs[key]) for key in kwargs])
-                msg='Expected arguments {} are not a subset of actual {}'.format(expected, actual)
+                msg = 'Expected arguments {} are not a subset of actual {}'.format(expected, actual)
                 self.assertTrue(set(expected).issubset(actual), msg=msg)
 
                 log_out_mock.assert_called_once_with(True)

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -45,16 +45,24 @@ class TestNotebookHelpers(unittest.TestCase):
     @patch(engines.__name__ + '.PapermillExecutePreprocessor')
     def test_start_timeout(self, preproc_mock):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, start_timeout=123)
-        preproc_mock.assert_called_once_with(
-            timeout=None, startup_timeout=123, kernel_name=kernel_name, log=logger
-        )
+        args, kwargs = preproc_mock.call_args
+        expected = [('timeout', None), ('startup_timeout', 123),
+                    ('kernel_name', kernel_name), ('log', logger)]
+        actual = set([(key, kwargs[key]) for key in kwargs])
+        self.assertTrue(set(expected).issubset(actual),
+                        msg='Expected arguments {} are not a subset of actual {}'.format(expected,
+                                                                                         actual))
 
     @patch(engines.__name__ + '.PapermillExecutePreprocessor')
     def test_default_start_timeout(self, preproc_mock):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname)
-        preproc_mock.assert_called_once_with(
-            timeout=None, startup_timeout=60, kernel_name=kernel_name, log=logger
-        )
+        args, kwargs = preproc_mock.call_args
+        expected = [('timeout', None), ('startup_timeout', 60),
+                    ('kernel_name', kernel_name), ('log', logger)]
+        actual = set([(key, kwargs[key]) for key in kwargs])
+        self.assertTrue(set(expected).issubset(actual),
+                        msg='Expected arguments {} are not a subset of actual {}'.format(expected,
+                                                                                         actual))
 
     def test_cell_insertion(self):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, {'msg': 'Hello'})


### PR DESCRIPTION
Allow user to pass notebook engine arguments via kwargs on pm.execute_notebook()
Right now there is no way (*I could find) to pass args like allow_errors and timeout