### PR TITLE
Update CONTRIBUTING.md for pip 19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ Install Papermill using:
 pip install -e '.[dev]'
 ```
 
+If you're using pip 19 or above, you should run
+```bash
+pip install -e '.[dev]' --no-use-pep517
+```
+
 _Note: When you are finished you can use `source deactivate` to go back to your base environment._
 
 ### Running Tests Locally


### PR DESCRIPTION
An additional flag is required for pip 19 to do the editable install
because papermill has a pyproject.toml file.