### PR TITLE
Don't auto-convert to datetimes when parsing YAML

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -11,7 +11,7 @@ import yaml
 import platform
 
 from .execute import execute_notebook
-from .iorw import read_yaml_file
+from .iorw import read_yaml_file, NoDatesSafeLoader
 from . import __version__ as papermill_version
 
 click.disable_unicode_literals_warning = True
@@ -141,11 +141,11 @@ def papermill(
     if inject_output_path or inject_paths:
         parameters_final['PAPERMILL_OUTPUT_PATH'] = output_path
     for params in parameters_base64 or []:
-        parameters_final.update(yaml.load(base64.b64decode(params)))
+        parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader))
     for files in parameters_file or []:
         parameters_final.update(read_yaml_file(files))
     for params in parameters_yaml or []:
-        parameters_final.update(yaml.load(params))
+        parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
     for name, value in parameters or []:
         parameters_final[name] = _resolve_type(value)
     for name, value in parameters_raw or []:

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -311,6 +311,15 @@ class GCSHandler(object):
         return path
 
 
+# Hack to make YAML loader not auto-convert datetimes
+# https://stackoverflow.com/a/52312810
+NoDatesSafeLoader = yaml.SafeLoader
+NoDatesSafeLoader.yaml_implicit_resolvers = {
+    k: [r for r in v if r[0] != 'tag:yaml.org,2002:timestamp'] for
+    k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
+}
+
+
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_io = PapermillIO()
 papermill_io.register("local", LocalHandler())
@@ -325,7 +334,7 @@ papermill_io.register_entry_points()
 
 def read_yaml_file(path):
     """Reads a YAML file from the location specified at 'path'."""
-    return yaml.load(papermill_io.read(path, ['.json', '.yaml', '.yml']))
+    return yaml.load(papermill_io.read(path, ['.json', '.yaml', '.yml']), Loader=NoDatesSafeLoader)
 
 
 def write_ipynb(nb, path):

--- a/papermill/tests/parameters/example.yaml
+++ b/papermill/tests/parameters/example.yaml
@@ -4,3 +4,4 @@ bar: "value"
 baz:
     k1: v1
     k2: v2
+a_date: 2019-01-01

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -127,7 +127,7 @@ class TestCLI(unittest.TestCase):
             'input.ipynb',
             'output.ipynb',
             # Last input wins dict update
-            {'foo': 54321, 'bar': 'value', 'baz': {'k2': 'v2', 'k1': 'v1'}},
+            {'foo': 54321, 'bar': 'value', 'baz': {'k2': 'v2', 'k1': 'v1'}, 'a_date': '2019-01-01'},
             engine_name=None,
             prepare_only=False,
             kernel_name=None,
@@ -148,6 +148,26 @@ class TestCLI(unittest.TestCase):
             'input.ipynb',
             'output.ipynb',
             {'foo': 'bar', 'foo2': ['baz']},
+            engine_name=None,
+            prepare_only=False,
+            kernel_name=None,
+            log_output=False,
+            progress_bar=True,
+            start_timeout=60,
+            report_mode=False,
+            cwd=None,
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_yaml_date(self, execute_patch):
+        self.runner.invoke(
+            papermill,
+            self.default_args + ['-y', 'a_date: 2019-01-01'],
+        )
+        execute_patch.assert_called_with(
+            'input.ipynb',
+            'output.ipynb',
+            {'a_date': '2019-01-01'},
             engine_name=None,
             prepare_only=False,
             kernel_name=None,
@@ -196,6 +216,30 @@ class TestCLI(unittest.TestCase):
             'output.ipynb',
             # Last input wins dict update
             {'foo': 1, 'bar': 2},
+            engine_name=None,
+            prepare_only=False,
+            kernel_name=None,
+            log_output=False,
+            progress_bar=True,
+            start_timeout=60,
+            report_mode=False,
+            cwd=None,
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_base64_date(self, execute_patch):
+        self.runner.invoke(
+            papermill,
+            self.default_args
+            + [
+                '--parameters_base64',
+                'YV9kYXRlOiAyMDE5LTAxLTAx',
+            ],
+        )
+        execute_patch.assert_called_with(
+            'input.ipynb',
+            'output.ipynb',
+            {'a_date': '2019-01-01'},
             engine_name=None,
             prepare_only=False,
             kernel_name=None,
@@ -525,6 +569,7 @@ class TestCLI(unittest.TestCase):
                 'baz': 'replace',
                 'yaml_foo': {'yaml_bar': 'yaml_baz'},
                 "base64_foo": "base64_bar",
+                'a_date': '2019-01-01',
             },
             engine_name='engine-that-could',
             prepare_only=True,


### PR DESCRIPTION
Fixes  #345

Right now the YAML load is parsing strings into datetime objects, which causes an error
for JSON serialization. This will prevent that parsing and keep them as strings.