### PR TITLE
git ignore pip-wheel-metadata directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ papermill/tests/fixtures/scissor.txt
 
 # Binder example
 binder/*run*.ipynb
+
+# pip generated wheel metadata
+pip-wheel-metadata


### PR DESCRIPTION
Noticed the `pip-wheel-metadata` directory get generated with an up to date pip, cluttering up the git repo locally. Now we can ignore it. 