### PR TITLE
update tqdm version and usage

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -97,14 +97,10 @@ class NotebookExecutionManager(object):
         self.end_time = None
         self.pbar = None
         if progress_bar:
-            # tqdm creates 2 globals lock which raise OSException if the execution
-            # environment does not have shared memory for processes, e.g. AWS Lambda
-            try:
-                # Layz import this as it import ipython which can be expensive
-                from tqdm.auto import tqdm
-                self.pbar = tqdm(total=len(self.nb.cells))
-            except OSError:
-                pass
+            # lazy import due to implict slow ipython import
+            from tqdm.auto import tqdm
+            self.pbar = tqdm(total=len(self.nb.cells), unit="cell",
+                             desc="Executing")
 
     def now(self):
         """Helper to return current UTC time"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyyaml
 nbformat
 nbconvert >= 5.5
 six
-tqdm >= 4.29.1
+tqdm >= 4.32.2
 jupyter_client
 requests
 entrypoints


### PR DESCRIPTION
- lock-triggered `OSError`s were fixed
  + tqdm/tqdm/issues/611 -> tqdm/tqdm/pull/617
  + tqdm/tqdm/issues/466 -> tqdm/tqdm/pull/698
- specify that the progressbar is about cell execution