### PR TITLE
Move IPython to dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+dev/
 
 # Spyder project settings
 .spyderproject

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,5 @@ wheel>=0.31.0
 setuptools>=38.6.0
 twine>=1.11.0
 google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
+ipython >= 5.0
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,4 +23,3 @@ setuptools>=38.6.0
 twine>=1.11.0
 google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
 ipython >= 5.0
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click
 future
 futures ; python_version < "3.0"
 backports.tempfile ; python_version < "3.0"
-ipython >= 5.0
 pyyaml
 nbformat
 nbconvert >= 5.5


### PR DESCRIPTION
Addresses #370 by moving the `IPython` dependency from `requirements.txt` to `requirements-dev.txt`.

Also add `dev` to `.gitignore`, which is created if you follow the virtualenv steps in the [contributing guide](https://github.com/nteract/papermill/blob/master/CONTRIBUTING.md#install-an-editable-version).

For my own edification, are there any tests in place to test this change? There's no isolation of dependencies vs test dependencies (at least in the virtualenv). What about this [test](https://github.com/nteract/papermill/blob/master/tox.ini#L28-L33)?