### PR TITLE
Adds explanation on how to parameterize. Closes #386

### DIFF
--- a/docs/usage-parameterize.rst
+++ b/docs/usage-parameterize.rst
@@ -20,6 +20,16 @@ To parameterize your notebook, designate a cell with the tag ``parameters``.
 
 .. image:: img/parameters.png
 
+
+If you are using the `Jupyter Notebook`_ interface, you must activate the tagging toolbar 
+by navigating to ``View``, ``Cell Toolbar``, and then ``Tags``.
+
+If you are using the `JupyterLab`_ interface, after selecting the cell you want to
+parameterize, click the cell inspector (wrench icon). Now you should edit the
+``Cell Metadata`` field by adding ``"tags":["parameters"]``. Learn more about the
+jupyter notebook format and metadata fields `here`_. You can also consider using
+an extension such as `jupyterlab-celltags`_.
+
 How do parameters work
 ----------------------
 
@@ -27,3 +37,9 @@ Papermill looks for the ``parameters`` cell and treats those values as defaults
 for the parameters passed in at execution time. It achieves this by inserting a
 cell after the tagged cell. If no cell is tagged with ``parameters`` a cell will
 be inserted to the front of the notebook.
+
+
+.. _`JupyterLab`: https://github.com/jupyterlab/jupyterlab
+.. _`Jupyter Notebook`: https://github.com/jupyter/notebook
+.. _`here`: https://ipython.org/ipython-doc/dev/notebook/nbformat.html#cell-metadata
+.. _`jupyterlab-celltags`: https://github.com/jupyterlab/jupyterlab-celltags


### PR DESCRIPTION
Adds explanation to documentation on how to create the tags for both Jupyter Notebook and JupyterLab:

<img width="695" alt="Screen Shot 2019-06-26 at 21 41 44" src="https://user-images.githubusercontent.com/26342344/60209618-4b0b7a00-985b-11e9-8103-d7325e54d559.png">
