### PR TITLE
Adds recommonmark dependency for building sphinx docs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ ipywidgets
 flake8
 tox
 bumpversion
+recommonmark
 pip>=18.1
 wheel>=0.31.0
 setuptools>=38.6.0


### PR DESCRIPTION
Adds [recommonmark](https://github.com/rtfd/recommonmark) dependency to [`requirements-dev.txt`](https://github.com/nteract/papermill/blob/master/requirements-dev.txt). Requested and referenced in #388 right [here](https://github.com/nteract/papermill/issues/386#issuecomment-506017765).