### PR TITLE
list parameter

### DIFF
--- a/docs/usage-execute.rst
+++ b/docs/usage-execute.rst
@@ -61,6 +61,23 @@ remain a string, even if it may be interpreted as a number or boolean.
 
     $ papermill local/input.ipynb s3://bkt/output.ipynb -r version 1.0
 
+Setting a list of values for a parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both ``-p`` and ``-r`` support multiple values, which will be turned into a list. For example:
+
+.. code-block:: bash
+
+   $ papermill input.ipynb output.ipynb -p foo bar baz 42 -p piyo hoge -r spam ham eggs 45
+
+will populate the parameter cell with:
+
+.. code-block:: python
+
+    foo = ['bar', 'baz', 42]
+    piyo = 'hoge'
+    spam = ['ham', 'eggs', '45']
+
 Using a parameters file
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -39,7 +39,7 @@ def print_papermill_version(ctx, param, value):
 @click.argument('notebook_path', required=not INPUT_PIPED)
 @click.argument('output_path', required=not (INPUT_PIPED or OUTPUT_PIPED))
 @click.option(
-    '--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.'
+    '--parameters', '-p', nargs=-1, multiple=True, help='Parameters to pass to the parameters cell.'
 )
 @click.option(
     '--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.'
@@ -171,8 +171,13 @@ def papermill(
         parameters_final.update(read_yaml_file(files))
     for params in parameters_yaml or []:
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
-    for name, value in parameters or []:
-        parameters_final[name] = _resolve_type(value)
+    for name, *values in parameters or []:
+        if not values:
+            raise ValueError
+        elif len(values) == 1:
+            parameters_final[name] = _resolve_type(values[0])
+        else:
+            parameters_final[name] = [_resolve_type(v) for v in values]
     for name, value in parameters_raw or []:
         parameters_final[name] = value
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -218,21 +218,17 @@ def papermill(
     for params in parameters_yaml or []:
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
     for name_values in parameters or []:
-        if len(name_values) == 1:
-            raise ValueError("There must be at least one value for key '{}'".format(name_values[0]))
         name, values = name_values[0], name_values[1:]
-        if len(values) == 1:
-            parameters_final[name] = _resolve_type(values[0])
-        else:
-            parameters_final[name] = [_resolve_type(v) for v in values]
+        if not values:
+            raise ValueError("There must be at least one value for key '{}'".format(name))
+        values = [_resolve_type(v) for v in values]
+        parameters_final[name] = values[0] if len(values) == 1 else values
     for name_values in parameters_raw or []:
-        if len(name_values) == 1:
-            raise ValueError("There must be at least one value for key '{}'".format(name_values[0]))
         name, values = name_values[0], name_values[1:]
-        if len(values) == 1:
-            parameters_final[name] = values[0]
-        else:
-            parameters_final[name] = list(values)
+        if not values:
+            raise ValueError("There must be at least one value for key '{}'".format(name))
+        values = list(values)
+        parameters_final[name] = values[0] if len(values) == 1 else values
 
     execute_notebook(
         notebook_path,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -218,18 +218,18 @@ def papermill(
     for params in parameters_yaml or []:
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
     for name_values in parameters or []:
-        name, values = name_values.pop(0), name_values
-        if not values:
-            raise ValueError("There must be at least one value for key '{}'".format(name))
-        elif len(values) == 1:
+        if len(name_values) == 1:
+            raise ValueError("There must be at least one value for key '{}'".format(name_values[0]))
+        name, values = name_values[0], name_values[1:]
+        if len(values) == 1:
             parameters_final[name] = _resolve_type(values[0])
         else:
             parameters_final[name] = [_resolve_type(v) for v in values]
     for name_values in parameters_raw or []:
-        name, values = name_values.pop(0), name_values
-        if not values:
-            raise ValueError("There must be at least one value for key '{}'".format(name))
-        elif len(values) == 1:
+        if len(name_values) == 1:
+            raise ValueError("There must be at least one value for key '{}'".format(name_values[0]))
+        name, values = name_values[0], name_values[1:]
+        if len(values) == 1:
             parameters_final[name] = values[0]
         else:
             parameters_final[name] = values

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -35,11 +35,56 @@ def print_papermill_version(ctx, param, value):
     ctx.exit()
 
 
+class OptionEatAll(click.Option):
+    # https://stackoverflow.com/a/48394004
+    def __init__(self, *args, **kwargs):
+        self.save_other_options = kwargs.pop('save_other_options', True)
+        nargs = kwargs.pop('nargs', -1)
+        assert nargs == -1, 'nargs, if set, must be -1 not {}'.format(nargs)
+        super(OptionEatAll, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            if self.save_other_options:
+                # grab everything up to the next option
+                while state.rargs and not done:
+                    for prefix in self._eat_all_parser.prefixes:
+                        if state.rargs[0].startswith(prefix):
+                            done = True
+                    if not done:
+                        value.append(state.rargs.pop(0))
+            else:
+                # grab everything remaining
+                value += state.rargs
+                state.rargs[:] = []
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+        return retval
+
+
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('notebook_path', required=not INPUT_PIPED)
 @click.argument('output_path', required=not (INPUT_PIPED or OUTPUT_PIPED))
 @click.option(
-    '--parameters', '-p', nargs=-1, multiple=True, help='Parameters to pass to the parameters cell.'
+    '--parameters', '-p', multiple=True, help='Parameters to pass to the parameters cell.',
+    cls=OptionEatAll,
 )
 @click.option(
     '--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.'

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -217,16 +217,18 @@ def papermill(
         parameters_final.update(read_yaml_file(files))
     for params in parameters_yaml or []:
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
-    for name, *values in parameters or []:
+    for name_values in parameters or []:
+        name, values = name_values.pop(0), name_values
         if not values:
-            raise ValueError(f"There must be at least one value for key '{name}'")
+            raise ValueError("There must be at least one value for key '{}'".format(name))
         elif len(values) == 1:
             parameters_final[name] = _resolve_type(values[0])
         else:
             parameters_final[name] = [_resolve_type(v) for v in values]
-    for name, *values in parameters_raw or []:
+    for name_values in parameters_raw or []:
+        name, values = name_values.pop(0), name_values
         if not values:
-            raise ValueError(f"There must be at least one value for key '{name}'")
+            raise ValueError("There must be at least one value for key '{}'".format(name))
         elif len(values) == 1:
             parameters_final[name] = values[0]
         else:

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -87,7 +87,8 @@ class OptionEatAll(click.Option):
     cls=OptionEatAll,
 )
 @click.option(
-    '--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.'
+    '--parameters_raw', '-r', multiple=True, help='Parameters to be read as raw string.',
+    cls=OptionEatAll,
 )
 @click.option(
     '--parameters_file', '-f', multiple=True, help='Path to YAML file containing parameters.'
@@ -218,13 +219,18 @@ def papermill(
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
     for name, *values in parameters or []:
         if not values:
-            raise ValueError
+            raise ValueError(f"There must be at least one value for key '{name}'")
         elif len(values) == 1:
             parameters_final[name] = _resolve_type(values[0])
         else:
             parameters_final[name] = [_resolve_type(v) for v in values]
-    for name, value in parameters_raw or []:
-        parameters_final[name] = value
+    for name, *values in parameters_raw or []:
+        if not values:
+            raise ValueError(f"There must be at least one value for key '{name}'")
+        elif len(values) == 1:
+            parameters_final[name] = values[0]
+        else:
+            parameters_final[name] = values
 
     execute_notebook(
         notebook_path,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -232,7 +232,7 @@ def papermill(
         if len(values) == 1:
             parameters_final[name] = values[0]
         else:
-            parameters_final[name] = values
+            parameters_final[name] = list(values)
 
     execute_notebook(
         notebook_path,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -105,12 +105,14 @@ class TestCLI(unittest.TestCase):
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_list_args(self, execute_patch):
         self.runner.invoke(
-            papermill, self.default_args + ['-p', 'foo', 'bar', 'baz', '--parameters', 'baz', '42']
+            papermill, self.default_args + ['-p', 'foo', 'bar', 'baz', '0',
+                                            '-p', 'one', 'two',
+                                            '--parameters', 'qux', '42']
         )
         execute_patch.assert_called_with(
             'input.ipynb',
             'output.ipynb',
-            {'foo': ['bar', 'baz'], 'baz': 42},
+            {'foo': ['bar', 'baz', 0], 'one': 'two', 'qux': 42},
             engine_name=None,
             request_save_on_cell_execute=True,
             prepare_only=False,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -145,6 +145,28 @@ class TestCLI(unittest.TestCase):
         )
 
     @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_raw_list_args(self, execute_patch):
+        self.runner.invoke(
+            papermill, self.default_args + ['-r', 'foo', 'bar', 'baz', '0',
+                                            '-r', 'one', 'two',
+                                            '--parameters_raw', 'qux', '42']
+        )
+        execute_patch.assert_called_with(
+            'input.ipynb',
+            'output.ipynb',
+            {'foo': ['bar', 'baz', '0'], 'one': 'two', 'qux': '42'},
+            engine_name=None,
+            request_save_on_cell_execute=True,
+            prepare_only=False,
+            kernel_name=None,
+            log_output=False,
+            progress_bar=True,
+            start_timeout=60,
+            report_mode=False,
+            cwd=None,
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_file(self, execute_patch):
         self.runner.invoke(
             papermill,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -103,6 +103,26 @@ class TestCLI(unittest.TestCase):
         )
 
     @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_list_args(self, execute_patch):
+        self.runner.invoke(
+            papermill, self.default_args + ['-p', 'foo', 'bar', 'baz', '--parameters', 'baz', '42']
+        )
+        execute_patch.assert_called_with(
+            'input.ipynb',
+            'output.ipynb',
+            {'foo': ['bar', 'baz'], 'baz': 42},
+            engine_name=None,
+            request_save_on_cell_execute=True,
+            prepare_only=False,
+            kernel_name=None,
+            log_output=False,
+            progress_bar=True,
+            start_timeout=60,
+            report_mode=False,
+            cwd=None,
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_raw(self, execute_patch):
         self.runner.invoke(
             papermill, self.default_args + ['-r', 'foo', 'bar', '--parameters_raw', 'baz', '42']


### PR DESCRIPTION
Hello!

This PR handles #363 

```
papermill input.ipynb output.ipynb -p my_list abc def ghi
```

But, it arguably relies on hacking `click.Option`, and `click` authors seem to be against variadic options [1].

Full credit goes to user stephen-rauch on stackoverflow [2]

The `class OptionEatAll` should probably be placed somewhere better...

[1] https://github.com/pallets/click/pull/259
[2] https://stackoverflow.com/a/48394004