### PR TITLE
Add stdout-file/stderr-file options

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -240,9 +240,9 @@ def papermill(
         parameters_final[name] = values[0] if len(values) == 1 else values
 
     execute_notebook(
-        notebook_path,
-        output_path,
-        parameters_final,
+        input_path=notebook_path,
+        output_path=output_path,
+        parameters=parameters_final,
         engine_name=engine,
         request_save_on_cell_execute=request_save_on_cell_execute,
         prepare_only=prepare_only,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -121,7 +121,7 @@ class OptionEatAll(click.Option):
     ),
 )
 @click.option('--engine', help='The execution engine name to use in evaluating the notebook.')
-@click.option('--request-save-on-cell-execute', default=True,
+@click.option('--request-save-on-cell-execute/--no-request-save-on-cell-execute', default=True,
               help='Request save notebook after each cell execution')
 @click.option(
     '--prepare-only/--prepare-execute',

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -136,7 +136,7 @@ class OptionEatAll(click.Option):
 @click.option(
     '--log-output/--no-log-output',
     default=False,
-    help="Flag for writing notebook output to stderr.",
+    help="Flag for writing notebook output to the configured logger.",
 )
 @click.option(
     '--log-level',

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -139,6 +139,16 @@ class OptionEatAll(click.Option):
     help="Flag for writing notebook output to the configured logger.",
 )
 @click.option(
+    '--stdout-file',
+    type=click.File(mode='w', encoding='utf-8'),
+    help="File to write notebook stdout output to.",
+)
+@click.option(
+    '--stderr-file',
+    type=click.File(mode='w', encoding='utf-8'),
+    help="File to write notebook stderr output to.",
+)
+@click.option(
     '--log-level',
     type=click.Choice(['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
     default='INFO',
@@ -177,6 +187,8 @@ def papermill(
     log_level,
     start_timeout,
     report_mode,
+    stdout_file,
+    stderr_file,
 ):
     """This utility executes a single notebook in a subprocess.
 
@@ -249,6 +261,8 @@ def papermill(
         kernel_name=kernel,
         progress_bar=progress_bar,
         log_output=log_output,
+        stdout_file=stdout_file,
+        stderr_file=stderr_file,
         start_timeout=start_timeout,
         report_mode=report_mode,
         cwd=cwd,

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -331,6 +331,8 @@ class NBConvertEngine(Engine):
         nb_man,
         kernel_name,
         log_output=False,
+        stdout_file=None,
+        stderr_file=None,
         start_timeout=60,
         execution_timeout=None,
         **kwargs
@@ -363,6 +365,8 @@ class NBConvertEngine(Engine):
             kernel_name=kernel_name,
             log=logger,
             log_output=log_output,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
         )
         preprocessor = PapermillExecutePreprocessor(**final_kwargs)
         preprocessor.preprocess(nb_man, safe_kwargs)

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -356,14 +356,15 @@ class NBConvertEngine(Engine):
         safe_kwargs = remove_args(['timeout', 'startup_timeout'], **kwargs)
 
         # Nicely handle preprocessor arguments prioritizing values set by engine
-        preprocessor = PapermillExecutePreprocessor(
-            **merge_kwargs(safe_kwargs,
-                           timeout=execution_timeout if execution_timeout else kwargs.get('timeout'),
-                           startup_timeout=start_timeout,
-                           kernel_name=kernel_name,
-                           log=logger))
-
-        preprocessor.log_output = log_output
+        final_kwargs = merge_kwargs(
+            safe_kwargs,
+            timeout=execution_timeout if execution_timeout else kwargs.get('timeout'),
+            startup_timeout=start_timeout,
+            kernel_name=kernel_name,
+            log=logger,
+            log_output=log_output,
+        )
+        preprocessor = PapermillExecutePreprocessor(**final_kwargs)
         preprocessor.preprocess(nb_man, safe_kwargs)
 
 

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -341,7 +341,8 @@ class NBConvertEngine(Engine):
         Args:
             nb (NotebookNode): Executable notebook object.
             kernel_name (str): Name of kernel to execute the notebook against.
-            log_output (bool): Flag for whether or not to write notebook output to stderr.
+            log_output (bool): Flag for whether or not to write notebook output to the
+                               configured logger.
             start_timeout (int): Duration to wait for kernel start-up.
             execution_timeout (int): Duration to wait before failing execution (default: never).
 

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -23,6 +23,8 @@ def execute_notebook(
     kernel_name=None,
     progress_bar=True,
     log_output=False,
+    stdout_file=None,
+    stderr_file=None,
     start_timeout=60,
     report_mode=False,
     cwd=None,
@@ -97,6 +99,8 @@ def execute_notebook(
                     progress_bar=progress_bar,
                     log_output=log_output,
                     start_timeout=start_timeout,
+                    stdout_file=stdout_file,
+                    stderr_file=stderr_file,
                     **engine_kwargs
                 )
 

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -49,7 +49,7 @@ def execute_notebook(
     progress_bar : bool, optional
         Flag for whether or not to show the progress bar.
     log_output : bool, optional
-        Flag for whether or not to write notebook output_path to `stderr`
+        Flag for whether or not to write notebook output to the configured logger
     start_timeout : int, optional
         Duration in seconds to wait for kernel start-up
     report_mode : bool, optional

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals, print_function
 
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
-from traitlets import Bool
+from traitlets import Bool, Instance
 
 
 class PapermillExecutePreprocessor(ExecutePreprocessor):
@@ -10,6 +10,8 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
     and updates outputs"""
 
     log_output = Bool(False).tag(config=True)
+    stdout_file = Instance(object, default_value=None).tag(config=True)
+    stderr_file = Instance(object, default_value=None).tag(config=True)
 
     def preprocess(self, nb_man, resources, km=None):
         """
@@ -67,17 +69,33 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
         return nb, resources
 
     def log_output_message(self, output):
+        """
+        Process a given output. May log it in the configured logger and/or write it into
+        the configured stdout/stderr files.
+
+        :param output: nbformat.notebooknode.NotebookNode
+        :return:
+        """
         if output.output_type == "stream":
+            content = "".join(output.text)
             if output.name == "stdout":
-                self.log.info("".join(output.text))
+                if self.log_output:
+                    self.log.info(content)
+                if self.stdout_file:
+                    self.stdout_file.write(content)
+                    self.stdout_file.flush()
             elif output.name == "stderr":
-                # In case users want to redirect stderr differently, pipe to warning
-                self.log.warning("".join(output.text))
-        elif "data" in output and "text/plain" in output.data:
+                if self.log_output:
+                    # In case users want to redirect stderr differently, pipe to warning
+                    self.log.warning(content)
+                if self.stderr_file:
+                    self.stderr_file.write(content)
+                    self.stderr_file.flush()
+        elif self.log_output and ("data" in output and "text/plain" in output.data):
             self.log.info("".join(output.data['text/plain']))
 
     def process_message(self, *arg, **kwargs):
         output = super(PapermillExecutePreprocessor, self).process_message(*arg, **kwargs)
-        if self.log_output and output:
+        if output and (self.log_output or self.stderr_file or self.stdout_file):
             self.log_output_message(output)
         return output

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -5,11 +5,14 @@ import sys
 
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
+from traitlets import Bool
 
 
 class PapermillExecutePreprocessor(ExecutePreprocessor):
     """Module containing a preprocessor that executes the code cells
     and updates outputs"""
+
+    log_output = Bool(False).tag(config=True)
 
     def preprocess(self, nb_man, resources, km=None):
         """

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -1,7 +1,4 @@
 from __future__ import unicode_literals, print_function
-from future.utils import raise_from  # noqa: F401
-
-import sys
 
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
@@ -78,9 +75,6 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
                 self.log.warning("".join(output.text))
         elif "data" in output and "text/plain" in output.data:
             self.log.info("".join(output.data['text/plain']))
-        # Force a flush to avoid long python buffering for messages
-        sys.stdout.flush()
-        sys.stderr.flush()
 
     def process_message(self, *arg, **kwargs):
         output = super(PapermillExecutePreprocessor, self).process_message(*arg, **kwargs)

--- a/papermill/tests/__init__.py
+++ b/papermill/tests/__init__.py
@@ -1,10 +1,16 @@
 import os
-import sys
+
+import six
 
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+
+if six.PY2:
+    kernel_name = 'python2'
+else:
+    kernel_name = 'python3'
 
 
 def get_notebook_path(*args):

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -72,9 +72,27 @@ def test_is_int(value, expected):
 
 
 class TestCLI(unittest.TestCase):
+    default_execute_kwargs = dict(
+        input_path='input.ipynb',
+        output_path='output.ipynb',
+        parameters={},
+        engine_name=None,
+        request_save_on_cell_execute=True,
+        prepare_only=False,
+        kernel_name=None,
+        log_output=False,
+        progress_bar=True,
+        start_timeout=60,
+        report_mode=False,
+        cwd=None,
+    )
+
     def setUp(self):
         self.runner = CliRunner()
-        self.default_args = ['input.ipynb', 'output.ipynb']
+        self.default_args = [
+            self.default_execute_kwargs['input_path'],
+            self.default_execute_kwargs['output_path'],
+        ]
         self.sample_yaml_file = os.path.join(
             os.path.dirname(__file__), 'parameters', 'example.yaml'
         )
@@ -82,46 +100,31 @@ class TestCLI(unittest.TestCase):
             os.path.dirname(__file__), 'parameters', 'example.json'
         )
 
+    def augment_execute_kwargs(self, **new_kwargs):
+        kwargs = self.default_execute_kwargs.copy()
+        kwargs.update(new_kwargs)
+        return kwargs
+
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters(self, execute_patch):
         self.runner.invoke(
             papermill, self.default_args + ['-p', 'foo', 'bar', '--parameters', 'baz', '42']
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'foo': 'bar', 'baz': 42},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': 42})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_list_args(self, execute_patch):
         self.runner.invoke(
-            papermill, self.default_args + ['-p', 'foo', 'bar', 'baz', '0',
-                                            '-p', 'one', 'two',
-                                            '--parameters', 'qux', '42']
+            papermill,
+            self.default_args
+            + ['-p', 'foo', 'bar', 'baz', '0', '-p', 'one', 'two', '--parameters', 'qux', '42'],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'foo': ['bar', 'baz', 0], 'one': 'two', 'qux': 42},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                parameters={'foo': ['bar', 'baz', 0], 'one': 'two', 'qux': 42}
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -130,40 +133,20 @@ class TestCLI(unittest.TestCase):
             papermill, self.default_args + ['-r', 'foo', 'bar', '--parameters_raw', 'baz', '42']
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'foo': 'bar', 'baz': '42'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': '42'})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_raw_list_args(self, execute_patch):
         self.runner.invoke(
-            papermill, self.default_args + ['-r', 'foo', 'bar', 'baz', '0',
-                                            '-r', 'one', 'two',
-                                            '--parameters_raw', 'qux', '42']
+            papermill,
+            self.default_args
+            + ['-r', 'foo', 'bar', 'baz', '0', '-r', 'one', 'two', '--parameters_raw', 'qux', '42'],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'foo': ['bar', 'baz', '0'], 'one': 'two', 'qux': '42'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                parameters={'foo': ['bar', 'baz', '0'], 'one': 'two', 'qux': '42'}
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -174,19 +157,15 @@ class TestCLI(unittest.TestCase):
             + ['-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'foo': 54321, 'bar': 'value', 'baz': {'k2': 'v2', 'k1': 'v1'}, 'a_date': '2019-01-01'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                # Last input wins dict update
+                parameters={
+                    'foo': 54321,
+                    'bar': 'value',
+                    'baz': {'k2': 'v2', 'k1': 'v1'},
+                    'a_date': '2019-01-01',
+                }
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -196,39 +175,14 @@ class TestCLI(unittest.TestCase):
             self.default_args + ['-y', '{"foo": "bar"}', '--parameters_yaml', '{"foo2": ["baz"]}'],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'foo': 'bar', 'foo2': ['baz']},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'foo': 'bar', 'foo2': ['baz']})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_yaml_date(self, execute_patch):
-        self.runner.invoke(
-            papermill,
-            self.default_args + ['-y', 'a_date: 2019-01-01'],
-        )
+        self.runner.invoke(papermill, self.default_args + ['-y', 'a_date: 2019-01-01'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'a_date': '2019-01-01'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -238,19 +192,10 @@ class TestCLI(unittest.TestCase):
             self.default_args + ['--parameters_yaml', '{"foo": "bar"}', '-y', '{"foo": ["baz"]}'],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'foo': ['baz']},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                # Last input wins dict update
+                parameters={'foo': ['baz']}
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -266,336 +211,118 @@ class TestCLI(unittest.TestCase):
             ],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'foo': 1, 'bar': 2},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'foo': 1, 'bar': 2})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_base64_date(self, execute_patch):
         self.runner.invoke(
-            papermill,
-            self.default_args
-            + [
-                '--parameters_base64',
-                'YV9kYXRlOiAyMDE5LTAxLTAx',
-            ],
+            papermill, self.default_args + ['--parameters_base64', 'YV9kYXRlOiAyMDE5LTAxLTAx']
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {'a_date': '2019-01-01'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_inject_input_path(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-input-path'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'PAPERMILL_INPUT_PATH': 'input.ipynb'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'PAPERMILL_INPUT_PATH': 'input.ipynb'})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_inject_output_path(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-output-path'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'PAPERMILL_OUTPUT_PATH': 'output.ipynb'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(parameters={'PAPERMILL_OUTPUT_PATH': 'output.ipynb'})
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_inject_paths(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-paths'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            # Last input wins dict update
-            {'PAPERMILL_INPUT_PATH': 'input.ipynb', 'PAPERMILL_OUTPUT_PATH': 'output.ipynb'},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                parameters={
+                    'PAPERMILL_INPUT_PATH': 'input.ipynb',
+                    'PAPERMILL_OUTPUT_PATH': 'output.ipynb',
+                }
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_engine(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--engine', 'engine-that-could'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name='engine-that-could',
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(engine_name='engine-that-could')
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_prepare_only(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--prepare-only'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=True,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(prepare_only=True))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_kernel(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-k', 'python3'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name='python3',
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(kernel_name='python3'))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_set_cwd(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--cwd', 'a/path/here'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd='a/path/here',
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(cwd='a/path/here'))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_progress_bar(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--progress-bar'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(progress_bar=True))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_no_progress_bar(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--no-progress-bar'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=False,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(progress_bar=False))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_log_output(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-output'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=True,
-            progress_bar=False,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                log_output=True,
+                progress_bar=False,  # Setting log-output should disable progress bar by default
+            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_log_output_plus_progress(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-output', '--progress-bar'])
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=True,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
+            **self.augment_execute_kwargs(log_output=True, progress_bar=True)
         )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_no_log_output(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--no-log-output'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(log_output=False))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_log_level(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-level', 'WARNING'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        # TODO: this does not actually test log-level being set
+        execute_patch.assert_called_with(**self.augment_execute_kwargs())
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_start_timeout(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--start_timeout', '123'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=123,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_report_mode(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--report-mode'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=True,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(report_mode=True))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_no_report_mode(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--not-report-mode'])
-        execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {},
-            engine_name=None,
-            request_save_on_cell_execute=True,
-            prepare_only=False,
-            kernel_name=None,
-            log_output=False,
-            progress_bar=True,
-            start_timeout=60,
-            report_mode=False,
-            cwd=None,
-        )
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(report_mode=False))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_version(self, execute_patch):
@@ -633,25 +360,25 @@ class TestCLI(unittest.TestCase):
             ],
         )
         execute_patch.assert_called_with(
-            'input.ipynb',
-            'output.ipynb',
-            {
-                'foo': '54321',
-                'bar': 'value',
-                'baz': 'replace',
-                'yaml_foo': {'yaml_bar': 'yaml_baz'},
-                "base64_foo": "base64_bar",
-                'a_date': '2019-01-01',
-            },
-            engine_name='engine-that-could',
-            request_save_on_cell_execute=True,
-            prepare_only=True,
-            kernel_name='R',
-            log_output=True,
-            progress_bar=False,
-            start_timeout=321,
-            report_mode=True,
-            cwd=None,
+            **self.augment_execute_kwargs(
+                parameters={
+                    'foo': '54321',
+                    'bar': 'value',
+                    'baz': 'replace',
+                    'yaml_foo': {'yaml_bar': 'yaml_baz'},
+                    "base64_foo": "base64_bar",
+                    'a_date': '2019-01-01',
+                },
+                engine_name='engine-that-could',
+                request_save_on_cell_execute=True,
+                prepare_only=True,
+                kernel_name='R',
+                log_output=True,
+                progress_bar=False,
+                start_timeout=321,
+                report_mode=True,
+                cwd=None,
+            )
         )
 
 

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -3,7 +3,7 @@ import copy
 import dateutil
 import unittest
 
-from mock import Mock, PropertyMock, patch, call
+from mock import Mock, patch, call
 from nbformat.notebooknode import NotebookNode
 
 from . import get_notebook_path
@@ -389,10 +389,6 @@ class TestNBConvertEngine(unittest.TestCase):
 
     def test_nb_convert_engine(self):
         with patch.object(engines, 'PapermillExecutePreprocessor') as pep_mock:
-            # Mock log_output calls
-            log_out_mock = PropertyMock()
-            type(pep_mock.return_value).log_output = log_out_mock
-
             with patch.object(NotebookExecutionManager, 'save') as save_mock:
                 nb = NBConvertEngine.execute_notebook(
                     self.nb,
@@ -411,13 +407,17 @@ class TestNBConvertEngine(unittest.TestCase):
                 pep_mock.assert_called_once()
 
                 args, kwargs = pep_mock.call_args
-                expected = [('timeout', 1000), ('startup_timeout', 30),
-                            ('kernel_name', 'python'), ('log', logger)]
+                expected = [
+                    ('timeout', 1000),
+                    ('startup_timeout', 30),
+                    ('kernel_name', 'python'),
+                    ('log', logger),
+                    ('log_output', True),
+                ]
                 actual = set([(key, kwargs[key]) for key in kwargs])
                 msg = 'Expected arguments {} are not a subset of actual {}'.format(expected, actual)
                 self.assertTrue(set(expected).issubset(actual), msg=msg)
 
-                log_out_mock.assert_called_once_with(True)
                 pep_mock.return_value.preprocess.assert_called_once_with(
                     AnyMock(NotebookExecutionManager), {'bar': 'baz'}
                 )

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -1,6 +1,5 @@
 import os
 import io
-import six
 import shutil
 import tempfile
 import unittest
@@ -20,13 +19,8 @@ from ..iorw import load_notebook_node
 from ..utils import chdir
 from ..execute import execute_notebook
 from ..exceptions import PapermillExecutionError
-from . import get_notebook_path
+from . import get_notebook_path, kernel_name
 
-
-if six.PY2:
-    kernel_name = 'python2'
-else:
-    kernel_name = 'python3'
 execute_notebook = partial(execute_notebook, kernel_name=kernel_name)
 
 

--- a/papermill/tests/test_preprocessor.py
+++ b/papermill/tests/test_preprocessor.py
@@ -12,7 +12,7 @@ from ..preprocess import PapermillExecutePreprocessor
 class TestPapermillExecutePreprocessor(unittest.TestCase):
     def setUp(self):
         self.nb = nbformat.read(get_notebook_path('test_logging.ipynb'), as_version=4)
-        self.preprocessor = PapermillExecutePreprocessor(log=logger)
+        self.preprocessor = PapermillExecutePreprocessor(log=logger, log_output=True)
         self.preprocessor.nb = self.nb
 
     def test_logging_stderr_msg(self):

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ basepython =
     docs: python3.6
     binder: python3.6
 deps = .[dev]
-commands = pytest -v --maxfail=2 --cov=papermill -W always
+commands = pytest -v --maxfail=2 --cov=papermill -W always {posargs}


### PR DESCRIPTION
This complements the existing log_output option to make it possible to more directly stream the notebook's stdout/stderr messages into separate files, without Papermill's internal log messages interfering.

Conveniently, `--stdout-file /dev/stdout --stderr-file /dev/stderr` lets one connect the two streams directly to their respective files.

All that is implemented in the last commit – there's a bunch of smaller preparatory commits that made it more convenient to develop this.