### PR TITLE
Add --skip-tag=... to have execution skip some tags

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -149,6 +149,14 @@ class OptionEatAll(click.Option):
     help="File to write notebook stderr output to.",
 )
 @click.option(
+    '--skip-tag',
+    'skip_tags',
+    type=str,
+    default=None,
+    multiple=True,
+    help="Cells with this tag will not be executed. May be passed multiple times.",
+)
+@click.option(
     '--log-level',
     type=click.Choice(['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
     default='INFO',
@@ -189,6 +197,7 @@ def papermill(
     report_mode,
     stdout_file,
     stderr_file,
+    skip_tags,
 ):
     """This utility executes a single notebook in a subprocess.
 
@@ -266,6 +275,7 @@ def papermill(
         start_timeout=start_timeout,
         report_mode=report_mode,
         cwd=cwd,
+        skip_tags=set(skip_tags or ()),
     )
 
 

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -28,6 +28,7 @@ def execute_notebook(
     start_timeout=60,
     report_mode=False,
     cwd=None,
+    skip_tags=None,
     **engine_kwargs
 ):
     """Executes a single notebook locally.
@@ -101,6 +102,7 @@ def execute_notebook(
                     start_timeout=start_timeout,
                     stdout_file=stdout_file,
                     stderr_file=stderr_file,
+                    skip_tags=skip_tags,
                     **engine_kwargs
                 )
 

--- a/papermill/preprocess.py
+++ b/papermill/preprocess.py
@@ -13,7 +13,8 @@ class PapermillExecutePreprocessor(ExecutePreprocessor):
     stdout_file = Instance(object, default_value=None).tag(config=True)
     stderr_file = Instance(object, default_value=None).tag(config=True)
 
-    def preprocess(self, nb_man, resources, km=None):
+
+    def preprocess(self, nb_man, resources=None, km=None):
         """
         Wraps the parent class process call slightly
         """

--- a/papermill/tests/notebooks/simple_execute.ipynb
+++ b/papermill/tests/notebooks/simple_execute.ipynb
@@ -16,7 +16,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+   "tags": [
+     "print"
+    ]
+   },
    "outputs": [],
    "source": [
     "print(msg)"


### PR DESCRIPTION
Passing `--skip-tag` (can be passed multiple times) will have the executor entirely skip cells endowed with that tag.

That status is recorded in the result notebook (`metadata.papermill.status` = `"skipped"`), as well as the tags that contributed to this skipping (`metadata.papermill.skip_tags`).

cc @juhakiili