### PR TITLE
Revert "list parameter (#411)"

### DIFF
--- a/docs/usage-execute.rst
+++ b/docs/usage-execute.rst
@@ -61,23 +61,6 @@ remain a string, even if it may be interpreted as a number or boolean.
 
     $ papermill local/input.ipynb s3://bkt/output.ipynb -r version 1.0
 
-Setting a list of values for a parameter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Both ``-p`` and ``-r`` support multiple values, which will be turned into a list. For example:
-
-.. code-block:: bash
-
-   $ papermill input.ipynb output.ipynb -p foo bar baz 42 -p piyo hoge -r spam ham eggs 45
-
-will populate the parameter cell with:
-
-.. code-block:: python
-
-    foo = ['bar', 'baz', 42]
-    piyo = 'hoge'
-    spam = ['ham', 'eggs', '45']
-
 Using a parameters file
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -35,60 +35,14 @@ def print_papermill_version(ctx, param, value):
     ctx.exit()
 
 
-class OptionEatAll(click.Option):
-    # https://stackoverflow.com/a/48394004
-    def __init__(self, *args, **kwargs):
-        self.save_other_options = kwargs.pop('save_other_options', True)
-        nargs = kwargs.pop('nargs', -1)
-        assert nargs == -1, 'nargs, if set, must be -1 not {}'.format(nargs)
-        super(OptionEatAll, self).__init__(*args, **kwargs)
-        self._previous_parser_process = None
-        self._eat_all_parser = None
-
-    def add_to_parser(self, parser, ctx):
-
-        def parser_process(value, state):
-            # method to hook to the parser.process
-            done = False
-            value = [value]
-            if self.save_other_options:
-                # grab everything up to the next option
-                while state.rargs and not done:
-                    for prefix in self._eat_all_parser.prefixes:
-                        if state.rargs[0].startswith(prefix):
-                            done = True
-                    if not done:
-                        value.append(state.rargs.pop(0))
-            else:
-                # grab everything remaining
-                value += state.rargs
-                state.rargs[:] = []
-            value = tuple(value)
-
-            # call the actual process
-            self._previous_parser_process(value, state)
-
-        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
-        for name in self.opts:
-            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
-            if our_parser:
-                self._eat_all_parser = our_parser
-                self._previous_parser_process = our_parser.process
-                our_parser.process = parser_process
-                break
-        return retval
-
-
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('notebook_path', required=not INPUT_PIPED)
 @click.argument('output_path', required=not (INPUT_PIPED or OUTPUT_PIPED))
 @click.option(
-    '--parameters', '-p', multiple=True, help='Parameters to pass to the parameters cell.',
-    cls=OptionEatAll,
+    '--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.'
 )
 @click.option(
-    '--parameters_raw', '-r', multiple=True, help='Parameters to be read as raw string.',
-    cls=OptionEatAll,
+    '--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.'
 )
 @click.option(
     '--parameters_file', '-f', multiple=True, help='Path to YAML file containing parameters.'
@@ -238,18 +192,10 @@ def papermill(
         parameters_final.update(read_yaml_file(files))
     for params in parameters_yaml or []:
         parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
-    for name_values in parameters or []:
-        name, values = name_values[0], name_values[1:]
-        if not values:
-            raise ValueError("There must be at least one value for key '{}'".format(name))
-        values = [_resolve_type(v) for v in values]
-        parameters_final[name] = values[0] if len(values) == 1 else values
-    for name_values in parameters_raw or []:
-        name, values = name_values[0], name_values[1:]
-        if not values:
-            raise ValueError("There must be at least one value for key '{}'".format(name))
-        values = list(values)
-        parameters_final[name] = values[0] if len(values) == 1 else values
+    for name, value in parameters or []:
+        parameters_final[name] = _resolve_type(value)
+    for name, value in parameters_raw or []:
+        parameters_final[name] = value
 
     execute_notebook(
         input_path=notebook_path,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -119,38 +119,12 @@ class TestCLI(unittest.TestCase):
         )
 
     @patch(cli.__name__ + '.execute_notebook')
-    def test_parameters_list_args(self, execute_patch):
-        self.runner.invoke(
-            papermill,
-            self.default_args
-            + ['-p', 'foo', 'bar', 'baz', '0', '-p', 'one', 'two', '--parameters', 'qux', '42'],
-        )
-        execute_patch.assert_called_with(
-            **self.augment_execute_kwargs(
-                parameters={'foo': ['bar', 'baz', 0], 'one': 'two', 'qux': 42}
-            )
-        )
-
-    @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_raw(self, execute_patch):
         self.runner.invoke(
             papermill, self.default_args + ['-r', 'foo', 'bar', '--parameters_raw', 'baz', '42']
         )
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': '42'})
-        )
-
-    @patch(cli.__name__ + '.execute_notebook')
-    def test_parameters_raw_list_args(self, execute_patch):
-        self.runner.invoke(
-            papermill,
-            self.default_args
-            + ['-r', 'foo', 'bar', 'baz', '0', '-r', 'one', 'two', '--parameters_raw', 'qux', '42'],
-        )
-        execute_patch.assert_called_with(
-            **self.augment_execute_kwargs(
-                parameters={'foo': ['bar', 'baz', '0'], 'one': 'two', 'qux': '42'}
-            )
         )
 
     @patch(cli.__name__ + '.execute_notebook')


### PR DESCRIPTION
This reverts commit 30c8ad1596a4850fea77d9a1cb3cba13e8a279c5.

@gshiba I found a fix for #417 but in in making that fix I discovered that there's no sane way to avoid capturing the notebook path when the last argument before the notebook input/outputs is a `-p`. We can't tell the `-p` option how many arguements there are and there's no way to detect if the notebook path is meant to be an additional list argument or a notebook path. The handler for notebook paths is definable by external users and has a wide range of acceptable values, so checking if the path is a notebook during option parsing is challenging to the point of impossibility for all use-cases.

See #427's example:

`papermill -p foo bar papermill/tests/notebooks/simple_execute.ipynb /tmp/out.ipynb`

After giving this some thought I think the only path forward is to revert the change. Additionally since the more complex option parsing caused two bugs that weren't obvious from review I think maybe the fancier option parsing is not a good idea for long-term maintenance of the repo.

We'll have to keep using the `-y '{"foo": ["bar", "baz"]}' pattern for passing list arguments to papermill.