### PR TITLE
Explicit utf-8 encoding on stdout

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -101,7 +101,13 @@ class PapermillIO(object):
 
     def write(self, buf, path, extensions=['.ipynb', '.json']):
         if path == '-':
-            return sys.stdout.write(buf)
+            try:
+                # Python 3
+                return sys.stdout.buffer.write(buf.encode('utf-8'))
+            except AttributeError:
+                # Python 2: add explicit utf-8 encoding
+                # https://github.com/nteract/papermill/issues/420
+                return sys.stdout.write(buf.encode('utf-8'))
 
         # Usually no return object here
         if not fnmatch.fnmatch(os.path.basename(path), '*.*'):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -187,10 +187,10 @@ class TestPapermillIO(unittest.TestCase):
 
     def test_write_stdout(self):
         file_content = u'Τὴ γλῶσσα μοῦ ἔδωσαν ἑλληνικὴ'
-        out = io.StringIO()
+        out = io.BytesIO()
         with mock.patch('sys.stdout', out):
             self.papermill_io.write(file_content, "-")
-            self.assertEqual(out.getvalue(), file_content)
+            self.assertEqual(out.getvalue(), file_content.encode('utf-8'))
 
     def test_pretty_path(self):
         self.assertEqual(self.papermill_io.pretty_path("fake/path"), "fake/path/pretty/1")


### PR DESCRIPTION
This implements the change suggested by @MSeal at #420.

I confirm that this solves the original issue with my notebook, as well as the one with `echo 'import world_bank_data as wb; wb.get_countries()' | jupytext --from py --to ipynb --set-kernel - | papermill > out.ipynb`.

@MSeal , I had to modify the test `test_write_stdout`. It is expected that I had to mock `stdout` with `io.BytesIO` instead of `io.StringIO`?