### PR TITLE
Fixed crashing R kernels with common illegal variable name

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -111,6 +111,8 @@ def test_translate_comment_r(test_input, expected):
             OrderedDict([['foo', 'bar'], ['baz', ['buz']]]),
             '# Parameters\nfoo = "bar"\nbaz = list("buz")\n',
         ),
+        # Underscores remove
+        ({"___foo": 5}, '# Parameters\nfoo = 5\n'),
     ],
 )
 def test_translate_codify_r(parameters, expected):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -161,6 +161,13 @@ class RTranslator(Translator):
     def comment(cls, cmt_str):
         return '# {}'.format(cmt_str).strip()
 
+    @classmethod
+    def assign(cls, name, str_val):
+        # Leading '_' aren't legal R variable names -- so we drop them when injecting
+        while (name.startswith("_")):
+            name = name[1:]
+        return '{} = {}'.format(name, str_val)
+
 
 class ScalaTranslator(Translator):
     @classmethod


### PR DESCRIPTION
Discussed this some off-line about approaches, but essentially passing `-p _foo bar` to papermill (common for system parameters you don't want namespace collisions on) breaks R kernel executions. To avoid this the PR strips leading `_` characters from parameter assignments.