### PR TITLE
Support list parameters (#363)

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -29,7 +29,7 @@ class ListOrString(click.types.StringParamType):
     sep = ','
 
     def convert(self, value, param, ctx):
-        val = super().convert(value, param, ctx)
+        val = super(ListOrString, self).convert(value, param, ctx)
         split_val = val.split(self.sep)
         if len(split_val) > 1:
             return split_val

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -24,6 +24,18 @@ INPUT_PIPED = S_ISFIFO(os.fstat(0).st_mode)
 OUTPUT_PIPED = not sys.stdout.isatty()
 
 
+class ListOrString(click.types.StringParamType):
+    name = 'list_or_string'
+    sep = ','
+
+    def convert(self, value, param, ctx):
+        val = super().convert(value, param, ctx)
+        split_val = val.split(self.sep)
+        if len(split_val) > 1:
+            return split_val
+        return val
+
+
 def print_papermill_version(ctx, param, value):
     if not value:
         return
@@ -39,7 +51,12 @@ def print_papermill_version(ctx, param, value):
 @click.argument('notebook_path', required=not INPUT_PIPED)
 @click.argument('output_path', required=not (INPUT_PIPED or OUTPUT_PIPED))
 @click.option(
-    '--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.'
+    '--parameters',
+    '-p',
+    type=ListOrString(),
+    nargs=2,
+    multiple=True,
+    help='Parameters to pass to the parameters cell.'
 )
 @click.option(
     '--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.'
@@ -234,7 +251,7 @@ def _is_int(value):
     """Use casting to check if value can convert to an `int`."""
     try:
         int(value)
-    except ValueError:
+    except (ValueError, TypeError):
         return False
     else:
         return True
@@ -244,7 +261,7 @@ def _is_float(value):
     """Use casting to check if value can convert to a `float`."""
     try:
         float(value)
-    except ValueError:
+    except (ValueError, TypeError):
         return False
     else:
         return True

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -119,6 +119,15 @@ class TestCLI(unittest.TestCase):
         )
 
     @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters(self, execute_patch):
+        self.runner.invoke(
+            papermill, self.default_args + ['-p', 'foo', 'bar,baz', '--parameters', 'buzz', '42']
+        )
+        execute_patch.assert_called_with(
+            **self.augment_execute_kwargs(parameters={'foo': ['bar', 'baz'], 'buzz': 42})
+        )
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_raw(self, execute_patch):
         self.runner.invoke(
             papermill, self.default_args + ['-r', 'foo', 'bar', '--parameters_raw', 'baz', '42']

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -1,3 +1,3 @@
 azure-datalake-store >= 0.0.30
-azure-storage-blob
+azure-storage-blob ~= 2.1
 requests >= 2.21.0


### PR DESCRIPTION
Closes #363 

This PR adds support for list parameters in the CLI. The current implementation supports comma-separated lists. We could of course change this. Also note I did not update documentation as I was a bit unsure. Does this feature deserve it's own section [here](https://github.com/nteract/papermill/blob/master/docs/usage-execute.rst#L39)?

I added a test around the CLI parsing. It likely does not cover the other small change which was to catch `TypeError`'s which were thrown when calling `int(list_)`

I was also able to test this with:

`papermill papermill/tests/notebooks/simple_execute.ipynb test.ipynb -p msg test,list,message` and parameters are passed into the notebook correctly. 