### PR TITLE
Translator for C# (.net-csharp) kernel

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -194,16 +194,13 @@ def test_translate_codify_scala(parameters, expected):
         ("foo", '"foo"'),
         ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
         ({"foo": "bar"},
-            'new Dictionary<string,Object>(new [] '
-            + '{ new KeyValuePair<string,Object>("foo" , "bar") })'),
+            'new Dictionary<string,Object>{ { "foo" , "bar" } }'),
         ({"foo": '"bar"'},
-            'new Dictionary<string,Object>(new [] '
-            + '{ new KeyValuePair<string,Object>("foo" , "\\"bar\\"") })'),
+            'new Dictionary<string,Object>{ { "foo" , "\\"bar\\"" } }'),
         (["foo"], 'new [] { "foo" }'),
         (["foo", '"bar"'], 'new [] { "foo", "\\"bar\\"" }'),
         ([{"foo": "bar"}],
-            'new [] { new Dictionary<string,Object>('
-            + 'new [] { new KeyValuePair<string,Object>("foo" , "bar") }) }'),
+            'new [] { new Dictionary<string,Object>{ { "foo" , "bar" } } }'),
         (12345, '12345'),
         (-54321, '-54321'),
         (1.2345, '1.2345'),
@@ -246,8 +243,7 @@ def test_translate_assign_csharp(input_name, input_value, expected):
         ({"foo": 1.1}, '// Parameters\nvar foo = 1.1;\n'),
         ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = new [] { "bar", "baz" };\n'),
         ({"foo": {'bar': 'baz'}},
-            '// Parameters\nvar foo = new Dictionary<string,Object>(new [] '
-            + '{ new KeyValuePair<string,Object>("bar" , "baz") });\n')
+            '// Parameters\nvar foo = new Dictionary<string,Object>{ { "bar" , "baz" } };\n')
     ],
 )
 def test_translate_codify_csharp(parameters, expected):

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -193,11 +193,17 @@ def test_translate_codify_scala(parameters, expected):
     [
         ("foo", '"foo"'),
         ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
-        ({"foo": "bar"}, 'new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "bar") })'),
-        ({"foo": '"bar"'}, 'new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "\\"bar\\"") })'),
+        ({"foo": "bar"},
+            'new Dictionary<Object,Object?>(new [] '
+            + '{ new KeyValuePair<Object,Object>("foo" , "bar") })'),
+        ({"foo": '"bar"'},
+            'new Dictionary<Object,Object?>(new [] '
+            + '{ new KeyValuePair<Object,Object>("foo" , "\\"bar\\"") })'),
         (["foo"], 'new [] { "foo" }'),
         (["foo", '"bar"'], 'new [] { "foo", "\\"bar\\"" }'),
-        ([{"foo": "bar"}], 'new [] { new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "bar") }) }'),
+        ([{"foo": "bar"}],
+            'new [] { new Dictionary<Object,Object?>('
+            + 'new [] { new KeyValuePair<Object,Object>("foo" , "bar") }) }'),
         (12345, '12345'),
         (-54321, '-54321'),
         (1.2345, '1.2345'),
@@ -239,7 +245,9 @@ def test_translate_assign_csharp(input_name, input_value, expected):
         ({"foo": 5}, '// Parameters\nvar foo = 5;\n'),
         ({"foo": 1.1}, '// Parameters\nvar foo = 1.1;\n'),
         ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = new [] { "bar", "baz" };\n'),
-        ({"foo": {'bar': 'baz'}}, '// Parameters\nvar foo = new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("bar" , "baz") });\n')
+        ({"foo": {'bar': 'baz'}},
+            '// Parameters\nvar foo = new Dictionary<Object,Object?>(new [] '
+            + '{ new KeyValuePair<Object,Object>("bar" , "baz") });\n')
     ],
 )
 def test_translate_codify_csharp(parameters, expected):

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -183,9 +183,9 @@ def test_translate_assign_scala(input_name, input_value, expected):
         ),
     ],
 )
-
 def test_translate_codify_scala(parameters, expected):
     assert translators.ScalaTranslator.codify(parameters) == expected
+
 
 # C# section
 @pytest.mark.parametrize(

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -229,6 +229,10 @@ def test_translate_type_julia(test_input, expected):
         ),
     ],
 )
+
+def test_translate_codify_csharp(parameters, expected) :
+    assert translators.csharpTranslator.codify(parameters) == expected 
+
 def test_translate_codify_julia(parameters, expected):
     assert translators.JuliaTranslator.codify(parameters) == expected
 

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -193,11 +193,11 @@ def test_translate_codify_scala(parameters, expected):
     [
         ("foo", '"foo"'),
         ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
-        ({"foo": "bar"}, 'new System.Collections.Specialized.NameValueCollection({{"foo" , "bar"}})'),
-        ({"foo": '"bar"'}, 'new System.Collections.Specialized.NameValueCollection({{"foo" , "\\"bar\\""}})'),
-        (["foo"], '["foo"]'),
-        (["foo", '"bar"'], '["foo", "\\"bar\\""]'),
-        ([{"foo": "bar"}], '[new System.Collections.Specialized.NameValueCollection({{"foo" , "bar"}})]'),
+        ({"foo": "bar"}, 'new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "bar") })'),
+        ({"foo": '"bar"'}, 'new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "\\"bar\\"") })'),
+        (["foo"], 'new [] { "foo" }'),
+        (["foo", '"bar"'], 'new [] { "foo", "\\"bar\\"" }'),
+        ([{"foo": "bar"}], 'new [] { new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("foo" , "bar") }) }'),
         (12345, '12345'),
         (-54321, '-54321'),
         (1.2345, '1.2345'),
@@ -223,8 +223,8 @@ def test_translate_comment_csharp(test_input, expected):
 @pytest.mark.parametrize(
     "input_name,input_value,expected",
     [
-        ("foo", '""', 'var foo = ""'),
-        ("foo", '"bar"', 'var foo = "bar"'),
+        ("foo", '""', 'var foo = "";'),
+        ("foo", '"bar"', 'var foo = "bar";'),
     ],
 )
 def test_translate_assign_csharp(input_name, input_value, expected):
@@ -234,12 +234,12 @@ def test_translate_assign_csharp(input_name, input_value, expected):
 @pytest.mark.parametrize(
     "parameters,expected",
     [
-        ({"foo": "bar"}, '// Parameters\nvar foo = "bar"\n'),
-        ({"foo": True}, '// Parameters\nvar foo = true\n'),
-        ({"foo": 5}, '// Parameters\nvar foo = 5\n'),
-        ({"foo": 1.1}, '// Parameters\nvar foo = 1.1\n'),
-        ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = ["bar", "baz"]\n'),
-        ({"foo": {'bar': 'baz'}}, '// Parameters\nvar foo = new System.Collections.Specialized.NameValueCollection({{"bar" , "baz"}})\n')
+        ({"foo": "bar"}, '// Parameters\nvar foo = "bar";\n'),
+        ({"foo": True}, '// Parameters\nvar foo = true;\n'),
+        ({"foo": 5}, '// Parameters\nvar foo = 5;\n'),
+        ({"foo": 1.1}, '// Parameters\nvar foo = 1.1;\n'),
+        ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = new [] { "bar", "baz" };\n'),
+        ({"foo": {'bar': 'baz'}}, '// Parameters\nvar foo = new Dictionary<Object,Object?>(new [] { new KeyValuePair<Object,Object>("bar" , "baz") });\n')
     ],
 )
 def test_translate_codify_csharp(parameters, expected):

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -194,16 +194,16 @@ def test_translate_codify_scala(parameters, expected):
         ("foo", '"foo"'),
         ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
         ({"foo": "bar"},
-            'new Dictionary<Object,Object?>(new [] '
-            + '{ new KeyValuePair<Object,Object>("foo" , "bar") })'),
+            'new Dictionary<string,Object>(new [] '
+            + '{ new KeyValuePair<string,Object>("foo" , "bar") })'),
         ({"foo": '"bar"'},
-            'new Dictionary<Object,Object?>(new [] '
-            + '{ new KeyValuePair<Object,Object>("foo" , "\\"bar\\"") })'),
+            'new Dictionary<string,Object>(new [] '
+            + '{ new KeyValuePair<string,Object>("foo" , "\\"bar\\"") })'),
         (["foo"], 'new [] { "foo" }'),
         (["foo", '"bar"'], 'new [] { "foo", "\\"bar\\"" }'),
         ([{"foo": "bar"}],
-            'new [] { new Dictionary<Object,Object?>('
-            + 'new [] { new KeyValuePair<Object,Object>("foo" , "bar") }) }'),
+            'new [] { new Dictionary<string,Object>('
+            + 'new [] { new KeyValuePair<string,Object>("foo" , "bar") }) }'),
         (12345, '12345'),
         (-54321, '-54321'),
         (1.2345, '1.2345'),
@@ -246,8 +246,8 @@ def test_translate_assign_csharp(input_name, input_value, expected):
         ({"foo": 1.1}, '// Parameters\nvar foo = 1.1;\n'),
         ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = new [] { "bar", "baz" };\n'),
         ({"foo": {'bar': 'baz'}},
-            '// Parameters\nvar foo = new Dictionary<Object,Object?>(new [] '
-            + '{ new KeyValuePair<Object,Object>("bar" , "baz") });\n')
+            '// Parameters\nvar foo = new Dictionary<string,Object>(new [] '
+            + '{ new KeyValuePair<string,Object>("bar" , "baz") });\n')
     ],
 )
 def test_translate_codify_csharp(parameters, expected):

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -183,8 +183,67 @@ def test_translate_assign_scala(input_name, input_value, expected):
         ),
     ],
 )
+
 def test_translate_codify_scala(parameters, expected):
     assert translators.ScalaTranslator.codify(parameters) == expected
+
+# C# section
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("foo", '"foo"'),
+        ('{"foo": "bar"}', '"{\\"foo\\": \\"bar\\"}"'),
+        ({"foo": "bar"}, 'new System.Collections.Specialized.NameValueCollection({{"foo" , "bar"}})'),
+        ({"foo": '"bar"'}, 'new System.Collections.Specialized.NameValueCollection({{"foo" , "\\"bar\\""}})'),
+        (["foo"], '["foo"]'),
+        (["foo", '"bar"'], '["foo", "\\"bar\\""]'),
+        ([{"foo": "bar"}], '[new System.Collections.Specialized.NameValueCollection({{"foo" , "bar"}})]'),
+        (12345, '12345'),
+        (-54321, '-54321'),
+        (1.2345, '1.2345'),
+        (-5432.1, '-5432.1'),
+        (2147483648, '2147483648L'),
+        (-2147483649, '-2147483649L'),
+        (True, 'true'),
+        (False, 'false')
+    ],
+)
+def test_translate_type_csharp(test_input, expected):
+    assert translators.CSharpTranslator.translate(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [("", '//'), ("foo", '// foo'), ("['best effort']", "// ['best effort']")],
+)
+def test_translate_comment_csharp(test_input, expected):
+    assert translators.CSharpTranslator.comment(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "input_name,input_value,expected",
+    [
+        ("foo", '""', 'var foo = ""'),
+        ("foo", '"bar"', 'var foo = "bar"'),
+    ],
+)
+def test_translate_assign_csharp(input_name, input_value, expected):
+    assert translators.CSharpTranslator.assign(input_name, input_value) == expected
+
+
+@pytest.mark.parametrize(
+    "parameters,expected",
+    [
+        ({"foo": "bar"}, '// Parameters\nvar foo = "bar"\n'),
+        ({"foo": True}, '// Parameters\nvar foo = true\n'),
+        ({"foo": 5}, '// Parameters\nvar foo = 5\n'),
+        ({"foo": 1.1}, '// Parameters\nvar foo = 1.1\n'),
+        ({"foo": ['bar', 'baz']}, '// Parameters\nvar foo = ["bar", "baz"]\n'),
+        ({"foo": {'bar': 'baz'}}, '// Parameters\nvar foo = new System.Collections.Specialized.NameValueCollection({{"bar" , "baz"}})\n')
+    ],
+)
+def test_translate_codify_csharp(parameters, expected):
+    assert translators.CSharpTranslator.codify(parameters) == expected
 
 
 @pytest.mark.parametrize(
@@ -229,10 +288,6 @@ def test_translate_type_julia(test_input, expected):
         ),
     ],
 )
-
-def test_translate_codify_csharp(parameters, expected) :
-    assert translators.csharpTranslator.codify(parameters) == expected 
-
 def test_translate_codify_julia(parameters, expected):
     assert translators.JuliaTranslator.codify(parameters) == expected
 

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -271,15 +271,16 @@ class MatlabTranslator(Translator):
             content += '{};\n'.format(cls.assign(name, cls.translate(val)))
         return content
 
-class CSharpTranslator(Translator) : 
 
-    @classmethod 
-    def translate_none(cls, val) : 
+class CSharpTranslator(Translator) :
+
+    @classmethod
+    def translate_none(cls, val) :
         # Can't figure out how to do this as nullable
         raise NotImplementedError("Option type not implemented for C#.")
 
     @classmethod
-    def translate_bool(cls, val) :  
+    def translate_bool(cls, val) :
         return 'true' if val else 'false'
 
     @classmethod
@@ -290,9 +291,10 @@ class CSharpTranslator(Translator) :
     @classmethod
     def translate_dict(cls, val):
         """Translate dicts to nontyped dictionary"""
- 
+
         kvps = ', '.join(
-            [f"new KeyValuePair<Object,Object>({cls.translate_str(k)} , {cls.translate(v)})" for k, v in val.items()]
+            [f"new KeyValuePair<Object,Object>({cls.translate_str(k)} , {cls.translate(v)})"
+             for k, v in val.items()]
         )
         return f'new Dictionary<Object,Object?>(new [] {{ {kvps} }})'
 
@@ -310,6 +312,7 @@ class CSharpTranslator(Translator) :
     def assign(cls, name, str_val):
         return 'var {} = {};'.format(name, str_val)
 
+
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
 papermill_translators.register("python", PythonTranslator)
@@ -317,8 +320,7 @@ papermill_translators.register("R", RTranslator)
 papermill_translators.register("scala", ScalaTranslator)
 papermill_translators.register("julia", JuliaTranslator)
 papermill_translators.register("matlab", MatlabTranslator)
-papermill_translators.register("C#", CSharpTranslator)
-papermill_translators.register(".net-csharp",CSharpTranslator)
+papermill_translators.register(".net-csharp", CSharpTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -293,10 +293,10 @@ class CSharpTranslator(Translator) :
         """Translate dicts to nontyped dictionary"""
 
         kvps = ', '.join(
-            [f"new KeyValuePair<Object,Object>({cls.translate_str(k)} , {cls.translate(v)})"
+            ["new KeyValuePair<Object,Object>({} , {})".format(cls.translate_str(k), cls.translate(v))
              for k, v in val.items()]
         )
-        return f'new Dictionary<Object,Object?>(new [] {{ {kvps} }})'
+        return 'new Dictionary<Object,Object?>(new [] {{ {} }})'.format(kvps)
 
     @classmethod
     def translate_list(cls, val):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -296,7 +296,7 @@ class CSharpTranslator(Translator) :
             ["new KeyValuePair<Object,Object>({} , {})".format(cls.translate_str(k), cls.translate(v))
              for k, v in val.items()]
         )
-        return 'new Dictionary<Object,Object?>(new [] {{ {} }})'.format(kvps)
+        return 'new Dictionary<string,Object?>(new [] {{ {} }})'.format(kvps)
 
     @classmethod
     def translate_list(cls, val):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -279,17 +279,21 @@ class CSharpTranslator(Translator) :
 
     @classmethod
     def translate_dict(cls, val):
-        """Translate dicts to NameValueCollection"""
+        """Translate dicts to nontyped dictionary"""
         escaped = ', '.join(
             ["{{{} , {}}}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
         )
-        return 'new System.Collections.Specialized.NameValueCollection({{{}}})'.format(escaped)
+
+        kvps = ', '.join(
+            [f"new KeyValuePair<Object,Object>({cls.translate_str(k)} , {cls.translate(v)})" for k, v in val.items()]
+        )
+        return f'new Dictionary<Object,Object?>(new[] {{ {kvps} }})'
 
     @classmethod
     def translate_list(cls, val):
         """Translate list to array"""
         escaped = ', '.join([cls.translate(v) for v in val])
-        return '[{}]'.format(escaped)
+        return 'new [] {{ {} }}'.format(escaped)
 
     @classmethod
     def comment(cls, cmt_str):
@@ -307,7 +311,7 @@ papermill_translators.register("scala", ScalaTranslator)
 papermill_translators.register("julia", JuliaTranslator)
 papermill_translators.register("matlab", MatlabTranslator)
 papermill_translators.register("C#", CSharpTranslator)
-papermill_translators.register(".net-csharp", CSharpTranslator)
+papermill_translators.register(".net-csharp",CSharpTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -272,6 +272,16 @@ class MatlabTranslator(Translator):
         return content
 
 class CSharpTranslator(Translator) : 
+
+    @classmethod 
+    def translate_none(cls, val) : 
+        # Can't figure out how to do this as nullable
+        raise NotImplementedError("Option type not implemented for C#.")
+
+    @classmethod
+    def translate_bool(cls, val) :  
+        return 'true' if val else 'false'
+
     @classmethod
     def translate_int(cls, val):
         strval = cls.translate_raw_str(val)
@@ -280,14 +290,11 @@ class CSharpTranslator(Translator) :
     @classmethod
     def translate_dict(cls, val):
         """Translate dicts to nontyped dictionary"""
-        escaped = ', '.join(
-            ["{{{} , {}}}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
-        )
-
+ 
         kvps = ', '.join(
             [f"new KeyValuePair<Object,Object>({cls.translate_str(k)} , {cls.translate(v)})" for k, v in val.items()]
         )
-        return f'new Dictionary<Object,Object?>(new[] {{ {kvps} }})'
+        return f'new Dictionary<Object,Object?>(new [] {{ {kvps} }})'
 
     @classmethod
     def translate_list(cls, val):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -271,6 +271,33 @@ class MatlabTranslator(Translator):
             content += '{};\n'.format(cls.assign(name, cls.translate(val)))
         return content
 
+class CSharpTranslator(Translator) : 
+    @classmethod
+    def translate_int(cls, val):
+        strval = cls.translate_raw_str(val)
+        return strval + "L" if (val > 2147483647 or val < -2147483648) else strval
+
+    @classmethod
+    def translate_dict(cls, val):
+        """Translate dicts to NameValueCollection"""
+        escaped = ', '.join(
+            ["{{{} , {}}}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
+        )
+        return 'new System.Collections.Specialized.NameValueCollection({{{}}})'.format(escaped)
+
+    @classmethod
+    def translate_list(cls, val):
+        """Translate list to array"""
+        escaped = ', '.join([cls.translate(v) for v in val])
+        return '[{}]'.format(escaped)
+
+    @classmethod
+    def comment(cls, cmt_str):
+        return '// {}'.format(cmt_str).strip()
+
+    @classmethod
+    def assign(cls, name, str_val):
+        return 'var {} = {}'.format(name, str_val)
 
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
@@ -279,6 +306,7 @@ papermill_translators.register("R", RTranslator)
 papermill_translators.register("scala", ScalaTranslator)
 papermill_translators.register("julia", JuliaTranslator)
 papermill_translators.register("matlab", MatlabTranslator)
+papermill_translators.register("c#", CSharpTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -293,10 +293,10 @@ class CSharpTranslator(Translator) :
         """Translate dicts to nontyped dictionary"""
 
         kvps = ', '.join(
-            ["new KeyValuePair<string,Object>({} , {})".format(cls.translate_str(k), cls.translate(v))
+            ["{{ {} , {} }}".format(cls.translate_str(k), cls.translate(v))
              for k, v in val.items()]
         )
-        return 'new Dictionary<string,Object>(new [] {{ {} }})'.format(kvps)
+        return 'new Dictionary<string,Object>{{ {} }}'.format(kvps)
 
     @classmethod
     def translate_list(cls, val):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -293,10 +293,10 @@ class CSharpTranslator(Translator) :
         """Translate dicts to nontyped dictionary"""
 
         kvps = ', '.join(
-            ["new KeyValuePair<Object,Object>({} , {})".format(cls.translate_str(k), cls.translate(v))
+            ["new KeyValuePair<string,Object>({} , {})".format(cls.translate_str(k), cls.translate(v))
              for k, v in val.items()]
         )
-        return 'new Dictionary<string,Object?>(new [] {{ {} }})'.format(kvps)
+        return 'new Dictionary<string,Object>(new [] {{ {} }})'.format(kvps)
 
     @classmethod
     def translate_list(cls, val):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -297,7 +297,7 @@ class CSharpTranslator(Translator) :
 
     @classmethod
     def assign(cls, name, str_val):
-        return 'var {} = {}'.format(name, str_val)
+        return 'var {} = {};'.format(name, str_val)
 
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
@@ -306,7 +306,8 @@ papermill_translators.register("R", RTranslator)
 papermill_translators.register("scala", ScalaTranslator)
 papermill_translators.register("julia", JuliaTranslator)
 papermill_translators.register("matlab", MatlabTranslator)
-papermill_translators.register("c#", CSharpTranslator)
+papermill_translators.register("C#", CSharpTranslator)
+papermill_translators.register(".net-csharp", CSharpTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters):

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -1,3 +1,3 @@
 azure-datalake-store >= 0.0.30
-azure-storage-blob
-requests >= 2.21.0
+azure-storage-blob == 2.1.0
+requests >= 2.1.0

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -1,3 +1,3 @@
 azure-datalake-store >= 0.0.30
 azure-storage-blob == 2.1.0
-requests >= 2.1.0
+requests >= 2.21.0


### PR DESCRIPTION
Translator for the recently-released .net-csharp kernel. 

## Pre-requisites

- Dotnet core 3.0 and 2.1 (https://dotnet.microsoft.com/download) 
- "Dotnet try" tool (https://www.nuget.org/packages/dotnet-try/) 
`dotnet tool install --global dotnet-try`

- .net kernels for Jupyter
`dotnet try jupyter install`

(See https://www.hanselman.com/blog/AnnouncingNETJupyterNotebooks.aspx )

## Notes

I had to lock the `azure-storage-blob` reference to the mid-2019 version, which is still supported. The Azure Python SDK was updated in late October with breaking changes. 

I didn't implement "None," although I think it might be possible to do something clever with `Nullable`s.

I implemented List as an array and Dict as a Dictionary<Object,Object?>. I could make them more consistent by making List `List<Object>` but that seems YAGNI. 

 