### PR TITLE
Use Black to format Python parameters for versions >= 3.6

### DIFF
--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -121,15 +121,40 @@ class PythonTranslator(Translator):
 
     @classmethod
     def translate_dict(cls, val):
-        escaped = ', '.join(
-            ["{}: {}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
+        # If dict has more than 3 items, use hanging indents
+        if len(val) > 3:
+            sepchar = '\n'
+            indent = '    '
+            close = '\n}'
+            open = '{\n'
+        else:
+            sepchar = ' '
+            indent = ''
+            close = '}'
+            open = '{'
+        escaped = (',' + sepchar).join(
+            ["{}{}: {}".format(indent, cls.translate_str(k), cls.translate(v))
+             for k, v in val.items()]
         )
-        return '{{{}}}'.format(escaped)
+        return open + escaped + close
 
     @classmethod
     def translate_list(cls, val):
-        escaped = ', '.join([cls.translate(v) for v in val])
-        return '[{}]'.format(escaped)
+        # If list has more than 5 items, use hanging indents
+        if len(val) > 5:
+            sepchar = '\n'
+            indent = '    '
+            close = '\n]'
+            open = '[\n'
+        else:
+            sepchar = ' '
+            indent = ''
+            close = ']'
+            open = '['
+        escaped = (', ' + sepchar).join(
+            [indent + cls.translate(v) for v in val]
+        )
+        return open + escaped + close
 
     @classmethod
     def comment(cls, cmt_str):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -137,7 +137,7 @@ class PythonTranslator(Translator):
 
     @classmethod
     def codify(cls, parameters):
-        content = super().codify(parameters)
+        content = super(cls, PythonTranslator).codify(parameters)
         if sys.version_info >= (3, 6):
             # Put content through the Black Python code formatter
             import black

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -141,7 +141,8 @@ class PythonTranslator(Translator):
         if sys.version_info >= (3, 6):
             # Put content through the Black Python code formatter
             import black
-            content = black.format_str(content, mode=black.FileMode())
+            fm = black.FileMode(string_normalization=False)
+            content = black.format_str(content, mode=fm)
         return content
 
 

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -137,7 +137,7 @@ class PythonTranslator(Translator):
 
     @classmethod
     def codify(cls, parameters):
-        content = super(cls, PythonTranslator).codify(parameters)
+        content = super(PythonTranslator, cls).codify(parameters)
         if sys.version_info >= (3, 6):
             # Put content through the Black Python code formatter
             import black

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,4 +1,5 @@
 import sys
+import black
 from six import string_types, integer_types
 from .exceptions import PapermillException
 
@@ -134,6 +135,12 @@ class PythonTranslator(Translator):
     @classmethod
     def comment(cls, cmt_str):
         return '# {}'.format(cmt_str).strip()
+
+    @classmethod
+    def codify(cls, parameters):
+        content = super().codify(parameters)
+        # Put content through the Black Python code formatter
+        return black.format_str(content, mode=black.FileMode())
 
 
 class RTranslator(Translator):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -138,7 +138,7 @@ class PythonTranslator(Translator):
     @classmethod
     def codify(cls, parameters):
         content = super().codify(parameters)
-        if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+        if sys.version_info >= (3, 6):
             # Put content through the Black Python code formatter
             import black
             content = black.format_str(content, mode=black.FileMode())

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,5 +1,4 @@
 import sys
-import black
 from six import string_types, integer_types
 from .exceptions import PapermillException
 
@@ -139,8 +138,11 @@ class PythonTranslator(Translator):
     @classmethod
     def codify(cls, parameters):
         content = super().codify(parameters)
-        # Put content through the Black Python code formatter
-        return black.format_str(content, mode=black.FileMode())
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+            # Put content through the Black Python code formatter
+            import black
+            content = black.format_str(content, mode=black.FileMode())
+        return content
 
 
 class RTranslator(Translator):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -121,40 +121,15 @@ class PythonTranslator(Translator):
 
     @classmethod
     def translate_dict(cls, val):
-        # If dict has more than 3 items, use hanging indents
-        if len(val) > 3:
-            sepchar = '\n'
-            indent = '    '
-            close = '\n}'
-            open = '{\n'
-        else:
-            sepchar = ' '
-            indent = ''
-            close = '}'
-            open = '{'
-        escaped = (',' + sepchar).join(
-            ["{}{}: {}".format(indent, cls.translate_str(k), cls.translate(v))
-             for k, v in val.items()]
+        escaped = ', '.join(
+            ["{}: {}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
         )
-        return open + escaped + close
+        return '{{{}}}'.format(escaped)
 
     @classmethod
     def translate_list(cls, val):
-        # If list has more than 5 items, use hanging indents
-        if len(val) > 5:
-            sepchar = '\n'
-            indent = '    '
-            close = '\n]'
-            open = '[\n'
-        else:
-            sepchar = ' '
-            indent = ''
-            close = ']'
-            open = '['
-        escaped = (', ' + sepchar).join(
-            [indent + cls.translate(v) for v in val]
-        )
-        return open + escaped + close
+        escaped = ', '.join([cls.translate(v) for v in val])
+        return '[{}]'.format(escaped)
 
     @classmethod
     def comment(cls, cmt_str):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ pytest-env>=0.6.2
 ipython>=5.0
 moto
 check-manifest
-black; python_version >= '3.6'
 attrs>=17.4.0
 pre-commit
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ jupyter_client
 requests
 entrypoints
 tenacity
+black; python_version >= '3.6'


### PR DESCRIPTION
Resolves #436.

I picked cutoff values for when to use newlines/indents based on my own practices. Was thinking of trying to limit line length, but we don't know the variable name so we can't calculate the full line length.