### PR TITLE
Fixed metadata writing on markdown and raw cells to follow v4 schema

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -153,7 +153,7 @@ class NotebookExecutionManager(object):
 
         for cell in self.nb.cells:
             # Reset the cell execution counts.
-            if cell.get("execution_count") is not None:
+            if cell.get("cell_type") == "code":
                 cell.execution_count = None
 
             # Clear out the papermill metadata for each cell.
@@ -164,7 +164,7 @@ class NotebookExecutionManager(object):
                 duration=None,
                 status=self.PENDING,  # pending, running, completed
             )
-            if cell.get("outputs") is not None:
+            if cell.get("cell_type") == "code":
                 cell.outputs = []
 
         self.save()

--- a/papermill/tests/notebooks/simple_execute.ipynb
+++ b/papermill/tests/notebooks/simple_execute.ipynb
@@ -23,10 +23,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": []
   }
  ],

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -102,7 +102,11 @@ class TestNotebookExecutionManager(unittest.TestCase):
             self.assertIsNone(cell.metadata.papermill['duration'])
             self.assertIsNone(cell.metadata.papermill['exception'])
             self.assertEqual(cell.metadata.papermill['status'], NotebookExecutionManager.PENDING)
-            self.assertIsNone(cell.execution_count)
+            self.assertIsNone(cell.get('execution_count'))
+            if cell.cell_type == 'code':
+                self.assertEqual(cell.get('outputs'), [])
+            else:
+                self.assertIsNone(cell.get('outputs'))
 
         nb_man.save.assert_called_once()
 
@@ -110,6 +114,12 @@ class TestNotebookExecutionManager(unittest.TestCase):
         nb_man = NotebookExecutionManager(self.nb)
         nb_man.notebook_start(nb=self.foo_nb)
         self.assertEqual(nb_man.nb.metadata['foo'], 'bar')
+
+    def test_notebook_start_markdown_code(self):
+        nb_man = NotebookExecutionManager(self.nb)
+        nb_man.notebook_start(nb=self.foo_nb)
+        self.assertNotIn('execution_count', nb_man.nb.cells[-1])
+        self.assertNotIn('outputs', nb_man.nb.cells[-1])
 
     def test_cell_start(self):
         nb_man = NotebookExecutionManager(self.nb)


### PR DESCRIPTION
Found we were making notebook outputs that sometimes didn't validate against nbformat schemas. This fix should correct that issue on markdown and raw cell types.