### PR TITLE
Add --execution_timeout flag for failing on too-slow cells

### DIFF
--- a/docs/reference/papermill-cli.rst
+++ b/docs/reference/papermill-cli.rst
@@ -50,7 +50,7 @@ Command Line options
                                       as notebook parameters.
       --engine TEXT                   The execution engine name to use in
                                       evaluating the notebook.
-      --request-save-on-cell-execute TEXT
+      --request-save-on-cell-execute / --no-request-save-on-cell-execute
                                       Request save notebook after each cell
                                       execution
       --prepare-only / --prepare-execute
@@ -60,10 +60,15 @@ Command Line options
       --cwd TEXT                      Working directory to run notebook in.
       --progress-bar / --no-progress-bar
                                       Flag for turning on the progress bar.
-      --log-output / --no-log-output  Flag for writing notebook output to stderr.
+      --log-output / --no-log-output  Flag for writing notebook output to the
+                                      configured logger.
+      --stdout-file FILENAME          File to write notebook stdout output to.
+      --stderr-file FILENAME          File to write notebook stderr output to.
       --log-level [NOTSET|DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                       Set log level
       --start_timeout INTEGER         Time in seconds to wait for kernel to start.
+      --execution_timeout INTEGER     Time in seconds to wait for each cell before
+                                      failing execution (default: forever)
       --report-mode / --no-report-mode
                                       Flag for hiding input.
       --version                       Flag for displaying the version.

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -57,8 +57,8 @@ options:
       --stderr-file FILENAME          File to write notebook stderr output to.
       --log-level [NOTSET|DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                       Set log level
-      --start_timeout INTEGER         Time in seconds to wait for kernel to start.
-      --execution_timeout INTEGER     Time in seconds to wait for each cell before
+      --start-timeout INTEGER         Time in seconds to wait for kernel to start.
+      --execution-timeout INTEGER     Time in seconds to wait for each cell before
                                       failing execution (default: forever)
       --report-mode / --no-report-mode
                                       Flag for hiding input.

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -41,7 +41,7 @@ options:
                                       as notebook parameters.
       --engine TEXT                   The execution engine name to use in
                                       evaluating the notebook.
-      --request-save-on-cell-execute TEXT
+      --request-save-on-cell-execute / --no-request-save-on-cell-execute
                                       Request save notebook after each cell
                                       execution
       --prepare-only / --prepare-execute
@@ -51,10 +51,15 @@ options:
       --cwd TEXT                      Working directory to run notebook in.
       --progress-bar / --no-progress-bar
                                       Flag for turning on the progress bar.
-      --log-output / --no-log-output  Flag for writing notebook output to stderr.
+      --log-output / --no-log-output  Flag for writing notebook output to the
+                                      configured logger.
+      --stdout-file FILENAME          File to write notebook stdout output to.
+      --stderr-file FILENAME          File to write notebook stderr output to.
       --log-level [NOTSET|DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                       Set log level
       --start_timeout INTEGER         Time in seconds to wait for kernel to start.
+      --execution_timeout INTEGER     Time in seconds to wait for each cell before
+                                      failing execution (default: forever)
       --report-mode / --no-report-mode
                                       Flag for hiding input.
       --version                       Flag for displaying the version.

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -118,10 +118,14 @@ def print_papermill_version(ctx, param, value):
     help='Set log level',
 )
 @click.option(
-    '--start_timeout', type=int, default=60, help="Time in seconds to wait for kernel to start."
+    '--start-timeout',
+    '--start_timeout',  # Backwards compatible naming
+    type=int,
+    default=60,
+    help="Time in seconds to wait for kernel to start.",
 )
 @click.option(
-    '--execution_timeout',
+    '--execution-timeout',
     type=int,
     help="Time in seconds to wait for each cell before failing execution (default: forever)",
 )

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -120,6 +120,11 @@ def print_papermill_version(ctx, param, value):
 @click.option(
     '--start_timeout', type=int, default=60, help="Time in seconds to wait for kernel to start."
 )
+@click.option(
+    '--execution_timeout',
+    type=int,
+    help="Time in seconds to wait for each cell before failing execution (default: forever)",
+)
 @click.option('--report-mode/--no-report-mode', default=False, help="Flag for hiding input.")
 @click.option(
     '--version',
@@ -150,6 +155,7 @@ def papermill(
     log_output,
     log_level,
     start_timeout,
+    execution_timeout,
     report_mode,
     stdout_file,
     stderr_file,
@@ -223,6 +229,7 @@ def papermill(
         start_timeout=start_timeout,
         report_mode=report_mode,
         cwd=cwd,
+        execution_timeout=execution_timeout,
     )
 
 

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -291,12 +291,17 @@ class TestCLI(unittest.TestCase):
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_start_timeout(self, execute_patch):
+        self.runner.invoke(papermill, self.default_args + ['--start-timeout', '123'])
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_start_timeout_backwards_compatibility(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--start_timeout', '123'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_execution_timeout(self, execute_patch):
-        self.runner.invoke(papermill, self.default_args + ['--execution_timeout', '123'])
+        self.runner.invoke(papermill, self.default_args + ['--execution-timeout', '123'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(execution_timeout=123))
 
     @patch(cli.__name__ + '.execute_notebook')
@@ -341,9 +346,9 @@ class TestCLI(unittest.TestCase):
                 '--autosave-cell-every',
                 '17',
                 '--no-progress-bar',
-                '--start_timeout',
+                '--start-timeout',
                 '321',
-                '--execution_timeout',
+                '--execution-timeout',
                 '654',
                 '--report-mode',
             ],

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -86,6 +86,7 @@ class TestCLI(unittest.TestCase):
         log_output=False,
         progress_bar=True,
         start_timeout=60,
+        execution_timeout=None,
         report_mode=False,
         cwd=None,
         stdout_file=None,
@@ -294,6 +295,11 @@ class TestCLI(unittest.TestCase):
         execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
 
     @patch(cli.__name__ + '.execute_notebook')
+    def test_execution_timeout(self, execute_patch):
+        self.runner.invoke(papermill, self.default_args + ['--execution_timeout', '123'])
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(execution_timeout=123))
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_report_mode(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--report-mode'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(report_mode=True))
@@ -337,6 +343,8 @@ class TestCLI(unittest.TestCase):
                 '--no-progress-bar',
                 '--start_timeout',
                 '321',
+                '--execution_timeout',
+                '654',
                 '--report-mode',
             ],
         )
@@ -358,6 +366,7 @@ class TestCLI(unittest.TestCase):
                 log_output=True,
                 progress_bar=False,
                 start_timeout=321,
+                execution_timeout=654,
                 report_mode=True,
                 cwd=None,
             )


### PR DESCRIPTION
This updates the CLI docs to include the full output of `--help` after
this patch; it seems that some flags have been added without
regenerating it, so the diff includes more than just this new
`--execution_timeout` flag.