### PR TITLE
Install jupyter_client's master with forward-ported 5.x branch's commits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pyyaml
 nbformat
 nbclient
 tqdm >= 4.32.2
-jupyter_client
 requests
 entrypoints
 tenacity

--- a/tox.ini
+++ b/tox.ini
@@ -67,4 +67,6 @@ basepython =
     docs: python3.6
     binder: python3.6
 deps = .[dev]
-commands = pytest -v --maxfail=2 --cov=papermill -W always {posargs}
+commands =
+    /bin/bash -c 'python -m pip install --ignore-installed git+https://git@github.com/davidbrochart/jupyter_client.git@5.x_to_master#egg=jupyter_client'
+    pytest -v --maxfail=2 --cov=papermill -W always {posargs}


### PR DESCRIPTION
This is to test `papermill` with jupyter/jupyter_client#513.