### PR TITLE
Use a markdown cell for error flagging, prettier than %%html

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -182,13 +182,7 @@ def raise_for_execution_errors(nb, output_path):
     if error:
         # Write notebook back out with the Error Message at the top of the Notebook.
         error_msg = ERROR_MESSAGE_TEMPLATE % str(error.exec_count)
-        error_msg_cell = nbformat.v4.new_code_cell(
-            source="%%html\n" + error_msg,
-            outputs=[
-                nbformat.v4.new_output(output_type="display_data", data={"text/html": error_msg})
-            ],
-            metadata={"inputHidden": True, "hide_input": True},
-        )
+        error_msg_cell = nbformat.v4.new_markdown_cell(error_msg)
         nb.cells = [error_msg_cell] + nb.cells
         write_ipynb(nb, output_path)
         raise error

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -283,8 +283,8 @@ class TestSysExit(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(get_notebook_path(notebook_name), result_path)
         nb = load_notebook_node(result_path)
-        self.assertEqual(nb.cells[0].cell_type, "code")
-        self.assertEqual(nb.cells[0].outputs[0].output_type, "display_data")
+        self.assertEqual(nb.cells[0].cell_type, "markdown")
+        self.assertRegex(nb.cells[0].source, r"^<span .*In \[2\].*</span>$")
         self.assertEqual(nb.cells[1].execution_count, 1)
         self.assertEqual(nb.cells[2].execution_count, 2)
         self.assertEqual(nb.cells[2].outputs[0].output_type, 'error')

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -148,8 +148,8 @@ class TestBrokenNotebook1(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = load_notebook_node(result_path)
-        self.assertEqual(nb.cells[0].cell_type, "code")
-        self.assertEqual(nb.cells[0].outputs[0].output_type, "display_data")
+        self.assertEqual(nb.cells[0].cell_type, "markdown")
+        self.assertRegex(nb.cells[0].source, r"^<span .*In \[2\].*</span>$")
         self.assertEqual(nb.cells[1].execution_count, 1)
         self.assertEqual(nb.cells[2].execution_count, 2)
         self.assertEqual(nb.cells[2].outputs[0].output_type, 'error')
@@ -169,8 +169,8 @@ class TestBrokenNotebook2(unittest.TestCase):
         with self.assertRaises(PapermillExecutionError):
             execute_notebook(path, result_path)
         nb = load_notebook_node(result_path)
-        self.assertEqual(nb.cells[0].cell_type, "code")
-        self.assertEqual(nb.cells[0].outputs[0].output_type, "display_data")
+        self.assertEqual(nb.cells[0].cell_type, "markdown")
+        self.assertRegex(nb.cells[0].source, r"^<span .*In \[2\].*</span>$")
         self.assertEqual(nb.cells[1].execution_count, 1)
         self.assertEqual(nb.cells[2].execution_count, 2)
         self.assertEqual(nb.cells[2].outputs[0].output_type, 'display_data')


### PR DESCRIPTION
Markdown is (mostly) a superset of HTML, meaning there's a lot of HTML one can include directly as markdown content. Papermill can use this to have a slightly cleaner error alert at the top of a failed notebook, by not having both code and output, just output only.

This makes the rendering of a broken notebook (such as `papermill/tests/notebooks/broken.ipynb`) cleaner in an interactive Jupyter instance, as well as on the GitHub and NBViewer static renderers:

Before:
- <https://gist.github.com/huonw/b08434842b6b9f6d45090141ae4327dd>
- <https://nbviewer.jupyter.org/gist/huonw/b08434842b6b9f6d45090141ae4327dd>
  ![image](https://user-images.githubusercontent.com/1203825/77136725-7e63f800-6abf-11ea-91e4-6b47a5c16e82.png)


After:
- <https://gist.github.com/huonw/f22a6caf6bf8c31538000b88e28c05da>
- <https://nbviewer.jupyter.org/gist/huonw/f22a6caf6bf8c31538000b88e28c05da>
  ![image](https://user-images.githubusercontent.com/1203825/77136767-8328ac00-6abf-11ea-9aa9-a23f7180781e.png)
