### PR TITLE
Fix warnings in pytest

### DIFF
--- a/papermill/tests/test_adl.py
+++ b/papermill/tests/test_adl.py
@@ -44,7 +44,7 @@ class ADLTest(unittest.TestCase):
         self.ls.assert_called_once_with("path/to/directory")
 
     def test_read_opens_and_reads_file(self):
-        self.assertEquals(
+        self.assertEqual(
             self.adl.read("adl://foo_store.azuredatalakestore.net/path/to/file"), ["a", "b", "c"]
         )
         self.fakeFile.__iter__.assert_called_once_with()

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 env =
     AWS_SECRET_ACCESS_KEY=foobar_secret
     AWS_ACCESS_KEY_ID=foobar_key
+filterwarnings =
+    ignore:.*imp module is deprecated.*:DeprecationWarning
+


### PR DESCRIPTION
- Ignore deprecated warning module
- Update assertEquals to assertEqual
For #228 