### PR TITLE
adding "comment" parameter for custom comment in injected cell

### DIFF
--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -51,7 +51,7 @@ def parameterize_path(path, parameters):
         raise PapermillMissingParameterException("Missing parameter {}".format(key_error))
 
 
-def parameterize_notebook(nb, parameters, report_mode=False):
+def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters'):
     """Assigned parameters into the appropriate place in the input notebook
 
     Parameters
@@ -62,6 +62,8 @@ def parameterize_notebook(nb, parameters, report_mode=False):
        Arbitrary keyword arguments to pass as notebook parameters
     report_mode : bool, optional
        Flag to set report mode
+    comment : str, optional
+        Comment added to the injected cell
     """
     # Load from a file if 'parameters' is a string.
     if isinstance(parameters, str):
@@ -74,7 +76,7 @@ def parameterize_notebook(nb, parameters, report_mode=False):
     language = nb.metadata.kernelspec.language
 
     # Generate parameter content based on the kernel_name
-    param_content = translate_parameters(kernel_name, language, parameters)
+    param_content = translate_parameters(kernel_name, language, parameters, comment)
 
     newcell = nbformat.v4.new_code_cell(source=param_content)
     newcell.metadata['tags'] = ['injected-parameters']

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -75,6 +75,15 @@ class TestNotebookParametrizing(unittest.TestCase):
         test_nb = parameterize_notebook(test_nb, {'msg': 'Hello'})
         self.assertEqual(self.count_nb_injected_parameter_cells(test_nb), 1)
 
+    def test_custom_comment(self):
+        test_nb = load_notebook_node(get_notebook_path("simple_execute.ipynb"))
+        test_nb = parameterize_notebook(test_nb, {'msg': 'Hello'},
+                                        comment='This is a custom comment')
+
+        cell_one = test_nb.cells[1]
+        first_line = cell_one['source'].split('\n')[0]
+        self.assertEqual(first_line, '# This is a custom comment')
+
 
 class TestBuiltinParameters(unittest.TestCase):
     def test_add_builtin_parameters_keeps_provided_parameters(self):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -108,8 +108,8 @@ class Translator(object):
         return '{} = {}'.format(name, str_val)
 
     @classmethod
-    def codify(cls, parameters):
-        content = '{}\n'.format(cls.comment('Parameters'))
+    def codify(cls, parameters, comment='Parameters'):
+        content = '{}\n'.format(cls.comment(comment))
         for name, val in parameters.items():
             content += '{}\n'.format(cls.assign(name, cls.translate(val)))
         return content
@@ -148,8 +148,8 @@ class PythonTranslator(Translator):
         return '# {}'.format(cmt_str).strip()
 
     @classmethod
-    def codify(cls, parameters):
-        content = super(PythonTranslator, cls).codify(parameters)
+    def codify(cls, parameters, comment='Parameters'):
+        content = super(PythonTranslator, cls).codify(parameters, comment)
         if sys.version_info >= (3, 6):
             # Put content through the Black Python code formatter
             import black
@@ -379,5 +379,5 @@ papermill_translators.register(".net-csharp", CSharpTranslator)
 papermill_translators.register(".net-fsharp", FSharpTranslator)
 
 
-def translate_parameters(kernel_name, language, parameters):
-    return papermill_translators.find_translator(kernel_name, language).codify(parameters)
+def translate_parameters(kernel_name, language, parameters, comment='Parameters'):
+    return papermill_translators.find_translator(kernel_name, language).codify(parameters, comment)


### PR DESCRIPTION
Related to #520.

Opening PR to discuss changes.

Added a "comment" parameter to the codify function, with a "Parameters" default value.

Exposed via the `parametrize_notebook` function.

Comments @MSeal?