### PR TITLE
Set jupyter_client version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyyaml
 nbformat
 nbclient >= 0.2.0
 tqdm >= 4.32.2
-jupyter_client
+jupyter_client >= 6.1.0
 requests
 entrypoints
 tenacity


### PR DESCRIPTION
As previously raised in #486 #492 #500 #522 and #523 if papermill is used in an environment with an older version of `jupyter_client` it will throw an error. This is caused by the dependency `nbclient>=0.2.0` that depends on `jupyter_client>=6.1.0`.

This dependency is overridden by papermill by having `jupyter_client` in `requirements.txt` without a version, meaning any version (even an older one) is accepted if already installed. To make sure the expected version of `jupyter_client` is installed we should set `jupyter_client>=6.1.0` to match `nbclient`.

Fixes #526 