### PR TITLE
Guess params by introspecting the _parameters_ cell

### DIFF
--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -6,7 +6,7 @@ options:
 
 .. code-block:: bash
 
-    Usage: papermill [OPTIONS] NOTEBOOK_PATH OUTPUT_PATH
+    Usage: papermill [OPTIONS] NOTEBOOK_PATH [OUTPUT_PATH]
 
       This utility executes a single notebook in a subprocess.
 
@@ -24,6 +24,9 @@ options:
       stdin and write it out to stdout.
 
     Options:
+      --help-notebook                 Display parameters information for the given
+                                      notebook path.
+
       -p, --parameters TEXT...        Parameters to pass to the parameters cell.
       -r, --parameters_raw TEXT...    Parameters to be read as raw string.
       -f, --parameters_file TEXT      Path to YAML file containing parameters.
@@ -32,34 +35,47 @@ options:
       --inject-input-path             Insert the path of the input notebook as
                                       PAPERMILL_INPUT_PATH as a notebook
                                       parameter.
+
       --inject-output-path            Insert the path of the output notebook as
                                       PAPERMILL_OUTPUT_PATH as a notebook
                                       parameter.
+
       --inject-paths                  Insert the paths of input/output notebooks
                                       as
                                       PAPERMILL_INPUT_PATH/PAPERMILL_OUTPUT_PATH
                                       as notebook parameters.
+
       --engine TEXT                   The execution engine name to use in
                                       evaluating the notebook.
+
       --request-save-on-cell-execute / --no-request-save-on-cell-execute
                                       Request save notebook after each cell
                                       execution
+
+      --autosave-cell-every INTEGER   How often in seconds to autosave the
+                                      notebook during long cell executions (0 to
+                                      disable)
+
       --prepare-only / --prepare-execute
                                       Flag for outputting the notebook without
                                       execution, but with parameters applied.
+
       -k, --kernel TEXT               Name of kernel to run.
       --cwd TEXT                      Working directory to run notebook in.
       --progress-bar / --no-progress-bar
                                       Flag for turning on the progress bar.
       --log-output / --no-log-output  Flag for writing notebook output to the
                                       configured logger.
+
       --stdout-file FILENAME          File to write notebook stdout output to.
       --stderr-file FILENAME          File to write notebook stderr output to.
       --log-level [NOTSET|DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                       Set log level
-      --start-timeout INTEGER         Time in seconds to wait for kernel to start.
+      --start-timeout, --start_timeout INTEGER
+                                      Time in seconds to wait for kernel to start.
       --execution-timeout INTEGER     Time in seconds to wait for each cell before
                                       failing execution (default: forever)
+
       --report-mode / --no-report-mode
                                       Flag for hiding input.
       --version                       Flag for displaying the version.

--- a/docs/usage-inspect.rst
+++ b/docs/usage-inspect.rst
@@ -1,0 +1,56 @@
+Inspect
+=======
+
+The two ways to inspect the notebook to discover its parameters are: (1) through the
+Python API and (2) through the command line interface.
+
+Execute via the Python API
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `inspect_notebook` function can be called to inspect a notebook:
+
+.. code-block:: python
+
+   inspect_notebook(<notebook path>)
+
+
+
+.. code-block:: python
+
+   import papermill as pm
+
+   pm.inspect_notebook('path/to/input.ipynb')
+
+.. note::
+    If your path is parametrized, you can pass those parameters in a dictionary
+    as second parameter:
+
+    ``inspect_notebook('path/to/input_{month}.ipynb', parameters={month='Feb'})``
+
+Inspect via CLI
+~~~~~~~~~~~~~~~
+
+To inspect a notebook using the CLI, enter the ``papermill --help-notebook`` command in the
+terminal with the notebook and optionally path parameters.
+
+.. seealso::
+
+    :doc:`CLI reference <./usage-cli>`
+
+Inspect a notebook
+^^^^^^^^^^^^^^^^^^
+
+Here's an example of a local notebook being inspected and an output example:
+
+.. code-block:: bash
+
+    papermill --help-notebook ./papermill/tests/notebooks/complex_parameters.ipynb
+
+    Usage: papermill [OPTIONS] NOTEBOOK_PATH [OUTPUT_PATH]
+
+    Parameters inferred for notebook './papermill/tests/notebooks/complex_parameters.ipynb':
+    msg: Unknown type (default None)
+    a: float (default 2.25)         Variable a
+    b: List[str] (default ['Hello','World'])
+                                    Nice list
+    c: NoneType (default None)

--- a/docs/usage-workflow.rst
+++ b/docs/usage-workflow.rst
@@ -21,7 +21,7 @@ a collection of notebooks.
    :maxdepth: 2
 
    usage-parameterize
-   usage-inspection
+   usage-inspect
    usage-execute
    usage-store
 

--- a/docs/usage-workflow.rst
+++ b/docs/usage-workflow.rst
@@ -21,6 +21,7 @@ a collection of notebooks.
    :maxdepth: 2
 
    usage-parameterize
+   usage-inspection
    usage-execute
    usage-store
 

--- a/papermill/__init__.py
+++ b/papermill/__init__.py
@@ -2,3 +2,4 @@ from .version import version as __version__
 
 from .exceptions import PapermillException, PapermillExecutionError
 from .execute import execute_notebook
+from .inspection import inspect_notebook

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -39,11 +39,6 @@ def print_papermill_version(ctx, param, value):
     ctx.exit()
 
 
-def print_notebook_help(ctx, param, value):
-    print(ctx.args, ctx.params, param, value)
-    ctx.exit()
-
-
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.pass_context
 @click.argument('notebook_path', required=not INPUT_PIPED)

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -16,7 +16,10 @@ import yaml
 import platform
 
 from .execute import execute_notebook
-from .iorw import read_yaml_file, NoDatesSafeLoader
+from .iorw import get_pretty_path, read_yaml_file, NoDatesSafeLoader
+from .inspection import display_notebook_help
+from .log import logger
+from .parameterize import parameterize_path, add_builtin_parameters
 from . import __version__ as papermill_version
 
 click.disable_unicode_literals_warning = True
@@ -35,10 +38,19 @@ def print_papermill_version(ctx, param, value):
     )
     ctx.exit()
 
+def print_notebook_help(ctx, param, value):
+    print(ctx.args, ctx.params, param, value)
+    ctx.exit()
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('notebook_path', required=not INPUT_PIPED)
-@click.argument('output_path', required=not (INPUT_PIPED or OUTPUT_PIPED))
+@click.argument('output_path', default="")
+@click.option(
+    '--help-notebook',
+    is_flag=True,
+    default=False,
+    help='Display parameters information for the given notebook path.'
+)
 @click.option(
     '--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.'
 )
@@ -142,6 +154,7 @@ def print_papermill_version(ctx, param, value):
 def papermill(
     notebook_path,
     output_path,
+    help_notebook,
     parameters,
     parameters_raw,
     parameters_file,
@@ -181,11 +194,16 @@ def papermill(
     from stdin and write it out to stdout.
 
     """
+    if not help_notebook:
+        required_output_path = not (INPUT_PIPED or OUTPUT_PIPED)
+        if required_output_path and not output_path:
+            raise click.UsageError("Missing argument 'OUTPUT_PATH'")
+
     if INPUT_PIPED and notebook_path and not output_path:
+        input_path = '-'
         output_path = notebook_path
-        notebook_path = '-'
     else:
-        notebook_path = notebook_path or '-'
+        input_path = notebook_path or '-'
         output_path = output_path or '-'
 
     if output_path == '-':
@@ -204,7 +222,7 @@ def papermill(
     # Read in Parameters
     parameters_final = {}
     if inject_input_path or inject_paths:
-        parameters_final['PAPERMILL_INPUT_PATH'] = notebook_path
+        parameters_final['PAPERMILL_INPUT_PATH'] = input_path
     if inject_output_path or inject_paths:
         parameters_final['PAPERMILL_OUTPUT_PATH'] = output_path
     for params in parameters_base64 or []:
@@ -218,9 +236,20 @@ def papermill(
     for name, value in parameters_raw or []:
         parameters_final[name] = value
 
+    path_parameters = add_builtin_parameters(parameters_final)
+    if help_notebook:
+        input_path = parameterize_path(notebook_path, path_parameters)
+        logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+        display_notebook_help(input_path)
+        return
+
+    input_path = parameterize_path(input_path, path_parameters)
+    output_path = parameterize_path(output_path, path_parameters)
+    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+    logger.info("Output Notebook: %s" % get_pretty_path(output_path))
     try:
         execute_notebook(
-            input_path=notebook_path,
+            input_path=input_path,
             output_path=output_path,
             parameters=parameters_final,
             engine_name=engine,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -16,10 +16,8 @@ import yaml
 import platform
 
 from .execute import execute_notebook
-from .iorw import get_pretty_path, read_yaml_file, NoDatesSafeLoader
+from .iorw import read_yaml_file, NoDatesSafeLoader
 from .inspection import display_notebook_help
-from .log import logger
-from .parameterize import parameterize_path, add_builtin_parameters
 from . import __version__ as papermill_version
 
 click.disable_unicode_literals_warning = True
@@ -235,17 +233,10 @@ def papermill(
     for name, value in parameters_raw or []:
         parameters_final[name] = value
 
-    path_parameters = add_builtin_parameters(parameters_final)
     if help_notebook:
-        input_path = parameterize_path(notebook_path, path_parameters)
-        logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
-        display_notebook_help(click_ctx, input_path)
+        display_notebook_help(click_ctx, input_path, parameters_final)
         return
 
-    input_path = parameterize_path(input_path, path_parameters)
-    output_path = parameterize_path(output_path, path_parameters)
-    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
-    logger.info("Output Notebook: %s" % get_pretty_path(output_path))
     try:
         execute_notebook(
             input_path=input_path,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -234,7 +234,7 @@ def papermill(
         parameters_final[name] = value
 
     if help_notebook:
-        display_notebook_help(click_ctx, input_path, parameters_final)
+        display_notebook_help(click_ctx, notebook_path, parameters_final)
         return
 
     try:

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -45,6 +45,7 @@ def print_notebook_help(ctx, param, value):
 
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.pass_context
 @click.argument('notebook_path', required=not INPUT_PIPED)
 @click.argument('output_path', default="")
 @click.option(
@@ -154,6 +155,7 @@ def print_notebook_help(ctx, param, value):
     help='Flag for displaying the version.',
 )
 def papermill(
+    click_ctx,
     notebook_path,
     output_path,
     help_notebook,
@@ -242,7 +244,7 @@ def papermill(
     if help_notebook:
         input_path = parameterize_path(notebook_path, path_parameters)
         logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
-        display_notebook_help(input_path)
+        display_notebook_help(click_ctx, input_path)
         return
 
     input_path = parameterize_path(input_path, path_parameters)

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -45,7 +45,7 @@ def print_papermill_version(ctx, param, value):
     '--help-notebook',
     is_flag=True,
     default=False,
-    help='Display parameters information for the given notebook path.'
+    help='Display parameters information for the given notebook path.',
 )
 @click.option(
     '--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.'
@@ -234,8 +234,7 @@ def papermill(
         parameters_final[name] = value
 
     if help_notebook:
-        display_notebook_help(click_ctx, notebook_path, parameters_final)
-        return
+        sys.exit(display_notebook_help(click_ctx, notebook_path, parameters_final))
 
     try:
         execute_notebook(

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -38,9 +38,11 @@ def print_papermill_version(ctx, param, value):
     )
     ctx.exit()
 
+
 def print_notebook_help(ctx, param, value):
     print(ctx.args, ctx.params, param, value)
     ctx.exit()
+
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('notebook_path', required=not INPUT_PIPED)

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -5,7 +5,7 @@ import nbformat
 
 from .log import logger
 from .exceptions import PapermillExecutionError
-from .iorw import write_ipynb, get_pretty_path, local_file_io_cwd, open_notebook
+from .iorw import write_ipynb, get_pretty_path, local_file_io_cwd, load_notebook_node
 from .engines import papermill_engines
 from .utils import chdir
 from .parameterize import add_builtin_parameters, parameterize_notebook,  parameterize_path
@@ -69,14 +69,14 @@ def execute_notebook(
     path_parameters = add_builtin_parameters(parameters)
     input_path = parameterize_path(input_path, path_parameters)
     output_path = parameterize_path(output_path, path_parameters)
+
     logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
     logger.info("Output Notebook: %s" % get_pretty_path(output_path))
-
     with local_file_io_cwd():
         if cwd is not None:
             logger.info("Working directory: {}".format(get_pretty_path(cwd)))
 
-        nb = open_notebook(input_path)
+        nb = load_notebook_node(input_path)
 
         # Parameterize the Notebook.
         if parameters:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -5,7 +5,7 @@ import nbformat
 
 from .log import logger
 from .exceptions import PapermillExecutionError
-from .iorw import load_notebook_node, write_ipynb, get_pretty_path, local_file_io_cwd, open_notebook
+from .iorw import write_ipynb, get_pretty_path, local_file_io_cwd, open_notebook
 from .engines import papermill_engines
 from .utils import chdir
 from .parameterize import parameterize_notebook

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -8,7 +8,7 @@ from .exceptions import PapermillExecutionError
 from .iorw import write_ipynb, get_pretty_path, local_file_io_cwd, open_notebook
 from .engines import papermill_engines
 from .utils import chdir
-from .parameterize import parameterize_notebook
+from .parameterize import add_builtin_parameters, parameterize_notebook,  parameterize_path
 
 
 def execute_notebook(
@@ -66,6 +66,12 @@ def execute_notebook(
     nb : NotebookNode
        Executed notebook object
     """
+    path_parameters = add_builtin_parameters(parameters)
+    input_path = parameterize_path(input_path, path_parameters)
+    output_path = parameterize_path(output_path, path_parameters)
+    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+    logger.info("Output Notebook: %s" % get_pretty_path(output_path))
+
     with local_file_io_cwd():
         if cwd is not None:
             logger.info("Working directory: {}".format(get_pretty_path(cwd)))

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -5,10 +5,10 @@ import nbformat
 
 from .log import logger
 from .exceptions import PapermillExecutionError
-from .iorw import load_notebook_node, write_ipynb, get_pretty_path, local_file_io_cwd
+from .iorw import load_notebook_node, write_ipynb, get_pretty_path, local_file_io_cwd, open_notebook
 from .engines import papermill_engines
 from .utils import chdir
-from .parameterize import parameterize_notebook, parameterize_path, add_builtin_parameters
+from .parameterize import parameterize_notebook
 
 
 def execute_notebook(
@@ -66,17 +66,11 @@ def execute_notebook(
     nb : NotebookNode
        Executed notebook object
     """
-    path_parameters = add_builtin_parameters(parameters)
-    input_path = parameterize_path(input_path, path_parameters)
-    output_path = parameterize_path(output_path, path_parameters)
-
-    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
-    logger.info("Output Notebook: %s" % get_pretty_path(output_path))
     with local_file_io_cwd():
         if cwd is not None:
             logger.info("Working directory: {}".format(get_pretty_path(cwd)))
 
-        nb = load_notebook_node(input_path)
+        nb = open_notebook(input_path)
 
         # Parameterize the Notebook.
         if parameters:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -5,10 +5,10 @@ import nbformat
 
 from .log import logger
 from .exceptions import PapermillExecutionError
-from .iorw import write_ipynb, get_pretty_path, local_file_io_cwd, load_notebook_node
+from .iorw import get_pretty_path, local_file_io_cwd, load_notebook_node, write_ipynb
 from .engines import papermill_engines
 from .utils import chdir
-from .parameterize import add_builtin_parameters, parameterize_notebook,  parameterize_path
+from .parameterize import add_builtin_parameters, parameterize_notebook, parameterize_path
 
 
 def execute_notebook(

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,14 +1,10 @@
- # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """
 Deduce parameters of a notebook from the parameters cell.
 """
-
-import ast
-
 import click
 
 from .iorw import get_pretty_path, open_notebook
-from .models import Parameter
 from .utils import any_tagged_cell
 
 
@@ -18,7 +14,7 @@ def display_notebook_help(notebook_path):
     the same automatic error messaging, but with the ability to hijack
     the normal help messaging for when a user types `--help` on an
     input notebook
-    
+
     Parameters
     ----------
     notebook_path : str
@@ -28,7 +24,7 @@ def display_notebook_help(notebook_path):
     pretty_path = get_pretty_path(notebook_path)
     click.echo("Usage: papermill [OPTIONS] {} [OUTPUT_PATH]".format(pretty_path))
     click.echo("\n  Parameters inferred for notebook '{}':".format(pretty_path))
-    
+
     if not any_tagged_cell(nb, "parameters"):
         click.echo("\n  No cell tagged 'parameters'")
         return

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -30,8 +30,12 @@ def display_notebook_help(ctx, notebook_path):
     params = nb.metadata['papermill']['default_parameters']
     if params:
         for p in params.values():
-            type_repr = p["inferred_type_name"] if p["inferred_type_name"] != "None" else "Unknown type"
-            click.echo("     {}: {} (default {})\t\t{}".format(p["name"], type_repr, p["default"], p["help"]))
+            type_repr = p["inferred_type_name"]
+            if type_repr == "None":
+                type_repr = "Unknown type"
+            click.echo(
+                "     {}: {} (default {})\t\t{}".format(p["name"], type_repr, p["default"], p["help"])
+            )
     else:
         click.echo(
             "\n  Can't infer anything about this notebook's parameters. "

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -29,8 +29,11 @@ def display_notebook_help(ctx, notebook_path):
 
     params = nb.metadata['papermill']['default_parameters']
     if params:
-        for p in params:
-            type_repr = p.inferred_type_name if p.inferred_type_name != "None" else "Unknown type"
-            click.echo("     {}: {} (default {})\t\t{}".format(p.name, type_repr, p.default, p.help))
+        for p in params.values():
+            type_repr = p["inferred_type_name"] if p["inferred_type_name"] != "None" else "Unknown type"
+            click.echo("     {}: {} (default {})\t\t{}".format(p["name"], type_repr, p["default"], p["help"]))
     else:
-        click.echo("\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.")
+        click.echo(
+            "\n  Can't infer anything about this notebook's parameters. "
+            "It may not have any parameter defined."
+        )

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -8,21 +8,19 @@ from .iorw import get_pretty_path, open_notebook
 from .utils import any_tagged_cell
 
 
-def display_notebook_help(notebook_path):
-    """
-    We make a separate function here with --help available to enable
-    the same automatic error messaging, but with the ability to hijack
-    the normal help messaging for when a user types `--help` on an
-    input notebook
+def display_notebook_help(ctx, notebook_path):
+    """Display help on notebook parameters.
 
     Parameters
     ----------
+    ctx : click.Context
+        Click context
     notebook_path : str
         Path to the notebook to be inspected
     """
     nb = open_notebook(notebook_path)
+    click.echo(ctx.command.get_usage(ctx))
     pretty_path = get_pretty_path(notebook_path)
-    click.echo("Usage: papermill [OPTIONS] {} [OUTPUT_PATH]".format(pretty_path))
     click.echo("\n  Parameters inferred for notebook '{}':".format(pretty_path))
 
     if not any_tagged_cell(nb, "parameters"):

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,14 +1,22 @@
 # -*- coding: utf-8 -*-
-"""
-Deduce parameters of a notebook from the parameters cell.
-"""
+"""Deduce parameters of a notebook from the parameters cell."""
 import click
 
 from .iorw import get_pretty_path, open_notebook
+from .log import logger
+from .parameterize import add_builtin_parameters, parameterize_path
 from .utils import any_tagged_cell
 
 
-def display_notebook_help(ctx, notebook_path):
+def _open_notebook(notebook_path, parameters):
+    path_parameters = add_builtin_parameters(parameters)
+    input_path = parameterize_path(notebook_path, path_parameters)
+    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+
+    return open_notebook(input_path)
+
+
+def display_notebook_help(ctx, notebook_path, parameters):
     """Display help on notebook parameters.
 
     Parameters
@@ -18,10 +26,10 @@ def display_notebook_help(ctx, notebook_path):
     notebook_path : str
         Path to the notebook to be inspected
     """
-    nb = open_notebook(notebook_path)
+    nb = _open_notebook(notebook_path, parameters)
     click.echo(ctx.command.get_usage(ctx))
     pretty_path = get_pretty_path(notebook_path)
-    click.echo("\n  Parameters inferred for notebook '{}':".format(pretty_path))
+    click.echo("\nParameters inferred for notebook '{}':".format(pretty_path))
 
     if not any_tagged_cell(nb, "parameters"):
         click.echo("\n  No cell tagged 'parameters'")
@@ -33,11 +41,38 @@ def display_notebook_help(ctx, notebook_path):
             type_repr = p["inferred_type_name"]
             if type_repr == "None":
                 type_repr = "Unknown type"
-            click.echo(
-                "     {}: {} (default {})\t\t{}".format(p["name"], type_repr, p["default"], p["help"])
-            )
+
+            definition = "  {}: {} (default {})".format(p["name"], type_repr, p["default"])
+            if len(definition) > 30:
+                if len(p["help"]):
+                    param_help = "".join((definition, "\n", 34 * " ", p["help"]))
+                else:
+                    param_help = definition
+            else:
+                param_help = "{:<34}{}".format(definition, p["help"])
+            click.echo(param_help)
     else:
         click.echo(
             "\n  Can't infer anything about this notebook's parameters. "
             "It may not have any parameter defined."
         )
+
+
+def inspect_notebook(notebook_path, parameters=None):
+    """Return the inferred notebook parameters.
+
+    Parameters
+    ----------
+    notebook_path : str
+        Path to notebook
+    parameters : dict, optional
+        Arbitrary keyword arguments to pass to the notebook parameters
+
+    Returns
+    -------
+    Dict[str, Parameter]
+       Mapping of (parameter name, {name, inferred_type_name, default, help})
+    """
+    nb = _open_notebook(notebook_path, parameters)
+
+    return nb.metadata['papermill']['default_parameters']

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -2,7 +2,7 @@
 """Deduce parameters of a notebook from the parameters cell."""
 import click
 
-from .iorw import get_pretty_path, open_notebook
+from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd
 from .log import logger
 from .parameterize import add_builtin_parameters, parameterize_path
 from .utils import any_tagged_cell
@@ -13,7 +13,8 @@ def _open_notebook(notebook_path, parameters):
     input_path = parameterize_path(notebook_path, path_parameters)
     logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
 
-    return open_notebook(input_path)
+    with local_file_io_cwd():
+        return load_notebook_node(input_path)
 
 
 def display_notebook_help(ctx, notebook_path, parameters):

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,0 +1,50 @@
+ # -*- coding: utf-8 -*-
+"""
+Deduce parameters of a notebook from the parameters cell.
+"""
+
+import ast
+
+import click
+
+from .iorw import get_pretty_path, open_notebook
+from .models import Parameter
+from .parameterize import find_first_tagged_cell_index
+from .translators import papermill_translators
+
+
+def display_notebook_help(notebook_path):
+    """
+    We make a separate function here with --help available to enable
+    the same automatic error messaging, but with the ability to hijack
+    the normal help messaging for when a user types `--help` on an
+    input notebook
+    
+    Parameters
+    ----------
+    notebook_path : str
+        Path to the notebook to be inspected
+    """
+    nb = open_notebook(notebook_path)
+    pretty_path = get_pretty_path(notebook_path)
+    click.echo("Usage: papermill [OPTIONS] {} [OUTPUT_PATH]".format(pretty_path))
+    click.echo("")
+    click.echo("  Parameters inferred for notebook '{}':".format(pretty_path))
+    
+    parameter_cell_idx = find_first_tagged_cell_index(nb, "parameters")
+    if parameter_cell_idx < 0:
+        click.echo("\n  No cell tagged 'parameters'")
+        return
+    
+    parameter_cell = nb.cells[parameter_cell_idx]
+    kernel_name = nb.metadata.kernelspec.name
+    language = nb.metadata.kernelspec.language
+
+    translator = papermill_translators.find_translator(kernel_name, language)
+    params = translator.inspect(parameter_cell)
+    if params:
+        for p in params:
+            type_repr = p.inferred_type_name if p.inferred_type_name != "None" else "Unknown type"
+            click.echo("     {}: {} (default {})\t{}".format(p.name, type_repr, p.default, p.help))
+    else:
+        click.echo("  Can't infer anything about this notebook's parameters")

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -436,7 +436,9 @@ def load_notebook_node(notebook_path):
         params = translator.inspect(parameter_cell)
         nb.metadata['papermill']['default_parameters'] = {p.name: p._asdict() for p in params}
     except NotImplementedError:
-        logger.warning("Translator for '{}' language does not support parameter introspection.".format(language))
+        logger.warning(
+            "Translator for '{}' language does not support parameter introspection.".format(language)
+        )
 
     return nb
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -433,7 +433,8 @@ def load_notebook_node(notebook_path):
 
     translator = papermill_translators.find_translator(kernel_name, language)
     try:
-        nb.metadata['papermill']['default_parameters'] = translator.inspect(parameter_cell)
+        params = translator.inspect(parameter_cell)
+        nb.metadata['papermill']['default_parameters'] = {p.name: p._asdict() for p in params}
     except NotImplementedError:
         logger.warning("Translator for '{}' language does not support parameter introspection.".format(language))
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -23,8 +23,7 @@ from .exceptions import (
     missing_environment_variable_generator,
 )
 from .log import logger
-from .utils import chdir, find_first_tagged_cell_index
-from .translators import papermill_translators
+from .utils import chdir
 
 try:
     from .s3 import S3
@@ -424,21 +423,6 @@ def load_notebook_node(notebook_path):
 
         if not hasattr(cell.metadata, 'papermill'):
             cell.metadata['papermill'] = dict()
-
-    # Force refreshing default parameters
-    parameter_cell_idx = find_first_tagged_cell_index(nb, "parameters")
-    parameter_cell = nb.cells[parameter_cell_idx]
-    kernel_name = nb.metadata.kernelspec.name
-    language = nb.metadata.kernelspec.language
-
-    translator = papermill_translators.find_translator(kernel_name, language)
-    try:
-        params = translator.inspect(parameter_cell)
-        nb.metadata['papermill']['default_parameters'] = {p.name: p._asdict() for p in params}
-    except NotImplementedError:
-        logger.warning(
-            "Translator for '{}' language does not support parameter introspection.".format(language)
-        )
 
     return nb
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -468,20 +468,3 @@ def local_file_io_cwd(path=None):
                 yield
             finally:
                 local_handler.cwd(old_cwd)
-
-
-def open_notebook(input_path):
-    """Open the input notebook.
-
-    Parameters
-    ----------
-    input_path : str
-        Path to input notebook
-
-    Returns
-    -------
-    nb : NotebookNode
-       Input notebook object
-    """
-    with local_file_io_cwd():
-        return load_notebook_node(input_path)

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -469,7 +469,7 @@ def local_file_io_cwd(path=None):
 
 def open_notebook(input_path):
     """Open the input notebook.
-    
+
     Parameters
     ----------
     input_path : str

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -450,3 +450,20 @@ def local_file_io_cwd(path=None):
                 yield
             finally:
                 local_handler.cwd(old_cwd)
+
+
+def open_notebook(input_path):
+    """Open the input notebook.
+    
+    Parameters
+    ----------
+    input_path : str
+        Path to input notebook
+
+    Returns
+    -------
+    nb : NotebookNode
+       Input notebook object
+    """
+    with local_file_io_cwd():
+        return load_notebook_node(input_path)

--- a/papermill/models.py
+++ b/papermill/models.py
@@ -1,9 +1,9 @@
-
+"""Models used by papermill"""
 from collections import namedtuple
 
 Parameter = namedtuple('Parameter', [
     'name',
-    'inferred_type_name',  # string of type    
+    'inferred_type_name',  # string of type
     'default',  # string representing the default value
     'help',
 ])

--- a/papermill/models.py
+++ b/papermill/models.py
@@ -1,4 +1,4 @@
-"""Models used by papermill"""
+"""Models used by papermill."""
 from collections import namedtuple
 
 Parameter = namedtuple('Parameter', [

--- a/papermill/models.py
+++ b/papermill/models.py
@@ -1,0 +1,9 @@
+
+from collections import namedtuple
+
+Parameter = namedtuple('Parameter', [
+    'name',
+    'inferred_type_name',  # string of type    
+    'default',  # string representing the default value
+    'help',
+])

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -1,10 +1,11 @@
 import copy
 import nbformat
 
-from .translators import translate_parameters
 from .log import logger
 from .exceptions import PapermillMissingParameterException
 from .iorw import read_yaml_file
+from .translators import translate_parameters
+from .utils import find_first_tagged_cell_index
 
 from uuid import uuid4
 from datetime import datetime
@@ -30,16 +31,6 @@ def add_builtin_parameters(parameters):
         with_builtin_parameters.update(parameters)
 
     return with_builtin_parameters
-
-
-def find_first_tagged_cell_index(nb, tag):
-    parameters_indices = []
-    for idx, cell in enumerate(nb.cells):
-        if tag in cell.metadata.tags:
-            parameters_indices.append(idx)
-    if not parameters_indices:
-        return -1
-    return parameters_indices[0]
 
 
 def parameterize_path(path, parameters):

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -32,6 +32,16 @@ def add_builtin_parameters(parameters):
     return with_builtin_parameters
 
 
+def find_first_tagged_cell_index(nb, tag):
+    parameters_indices = []
+    for idx, cell in enumerate(nb.cells):
+        if tag in cell.metadata.tags:
+            parameters_indices.append(idx)
+    if not parameters_indices:
+        return -1
+    return parameters_indices[0]
+
+
 def parameterize_path(path, parameters):
     """Format a path with a provided dictionary of parameters
 
@@ -85,8 +95,8 @@ def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters
         newcell.metadata['jupyter'] = newcell.get('jupyter', {})
         newcell.metadata['jupyter']['source_hidden'] = True
 
-    param_cell_index = _find_first_tagged_cell_index(nb, 'parameters')
-    injected_cell_index = _find_first_tagged_cell_index(nb, 'injected-parameters')
+    param_cell_index = find_first_tagged_cell_index(nb, 'parameters')
+    injected_cell_index = find_first_tagged_cell_index(nb, 'injected-parameters')
     if injected_cell_index >= 0:
         # Replace the injected cell with a new version
         before = nb.cells[:injected_cell_index]
@@ -105,13 +115,3 @@ def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters
     nb.metadata.papermill['parameters'] = parameters
 
     return nb
-
-
-def _find_first_tagged_cell_index(nb, tag):
-    parameters_indices = []
-    for idx, cell in enumerate(nb.cells):
-        if tag in cell.metadata.tags:
-            parameters_indices.append(idx)
-    if not parameters_indices:
-        return -1
-    return parameters_indices[0]

--- a/papermill/tests/notebooks/complex_parameters.ipynb
+++ b/papermill/tests/notebooks/complex_parameters.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msg = None\n",
+    "a: float = 2.25 # Variable a\n",
+    "b = [\n",
+    "    'Hello', # First element\n",
+    "# Dummy comment\n",
+    "    'World'\n",
+    "] # type: List[str] Nice list\n",
+    "\n",
+    "# Interesting c variable\n",
+    "c: \"NoneType\" = None"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/notebooks/complex_parameters.ipynb
+++ b/papermill/tests/notebooks/complex_parameters.ipynb
@@ -19,7 +19,11 @@
     "] # type: List[str] Nice list\n",
     "\n",
     "# Interesting c variable\n",
-    "c: \"NoneType\" = None"
+    "c: \"NoneType\" = None\n",
+    "# Not introspectable line\n",
+    "d = a == 3\n",
+    "# Broken name definition\n",
+    "= 2"
    ]
   }
  ],

--- a/papermill/tests/notebooks/notimplemented_translator.ipynb
+++ b/papermill/tests/notebooks/notimplemented_translator.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msg = None"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "r",
+   "language": "R",
+   "name": "r"
+  },
+  "language_info": {
+   "name": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -331,6 +331,13 @@ class TestCLI(unittest.TestCase):
         execute_patch.assert_not_called()
 
     @patch(cli.__name__ + '.execute_notebook')
+    @patch(cli.__name__ + '.display_notebook_help')
+    def test_help_notebook(self, display_notebook_help, execute_path):
+        self.runner.invoke(papermill, ['--help-notebook', 'input_path.ipynb'])
+        execute_path.assert_not_called()
+        display_notebook_help.assert_called_with('input_path.ipynb')
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_many_args(self, execute_patch):
         self.runner.invoke(
             papermill,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -134,8 +134,9 @@ class TestCLI(unittest.TestCase):
     def test_parameters_file(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + ['-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file],
+            self.default_args + [
+                '-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file
+            ],
         )
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(
@@ -193,8 +194,7 @@ class TestCLI(unittest.TestCase):
     def test_parameters_base64(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + [
+            self.default_args + [
                 '--parameters_base64',
                 'eyJmb28iOiAicmVwbGFjZWQiLCAiYmFyIjogMn0=',
                 '-b',
@@ -341,8 +341,7 @@ class TestCLI(unittest.TestCase):
     def test_many_args(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + [
+            self.default_args + [
                 '-f',
                 self.sample_yaml_file,
                 '-y',

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -335,7 +335,8 @@ class TestCLI(unittest.TestCase):
     def test_help_notebook(self, display_notebook_help, execute_path):
         self.runner.invoke(papermill, ['--help-notebook', 'input_path.ipynb'])
         execute_path.assert_not_called()
-        display_notebook_help.assert_called_with('input_path.ipynb')
+        assert display_notebook_help.call_count == 1
+        assert display_notebook_help.call_args[0][1] == 'input_path.ipynb'
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_many_args(self, execute_patch):

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from click import Context
 
 from papermill.iorw import load_notebook_node
+from papermill.inspection import display_notebook_help
 
 
 NOTEBOOKS_PATH = Path(__file__).parent / "notebooks"
@@ -10,6 +13,13 @@ NOTEBOOKS_PATH = Path(__file__).parent / "notebooks"
 
 def _get_fullpath(name):
     return NOTEBOOKS_PATH / name
+
+
+@pytest.fixture
+def click_context():
+    mock = MagicMock(spec=Context, command=MagicMock())
+    mock.command.get_usage.return_value = "Dummy usage"
+    return mock
 
 
 @pytest.mark.parametrize(
@@ -46,3 +56,52 @@ def test_default_parameters(name, expected):
     nb = load_notebook_node(str(name))
 
     assert nb.metadata['papermill']['default_parameters'] == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (
+            _get_fullpath("no_parameters.ipynb"),
+            [
+                "Dummy usage",
+                "\n  Parameters inferred for notebook '{name}':",
+                "\n  No cell tagged 'parameters'",
+            ],
+        ),
+        (
+            _get_fullpath("simple_execute.ipynb"),
+            [
+                "Dummy usage",
+                "\n  Parameters inferred for notebook '{name}':",
+                "     msg: Unknown type (default None)\t\t",
+            ],
+        ),
+        (
+            _get_fullpath("complex_parameters.ipynb"),
+            [
+                "Dummy usage",
+                "\n  Parameters inferred for notebook '{name}':",
+                "     msg: Unknown type (default None)\t\t",
+                "     a: float (default 2.25)\t\tVariable a",
+                "     b: List[str] (default ['Hello','World'])\t\tNice list",
+                "     c: NoneType (default None)\t\t",
+            ],
+        ),
+        (
+            _get_fullpath("notimplemented_translator.ipynb"),
+            [
+                "Dummy usage",
+                "\n  Parameters inferred for notebook '{name}':",
+                "\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.",  # noqa
+            ],
+        ),
+    ],
+)
+def test_display_notebook_help(click_context, name, expected):
+    with patch("papermill.inspection.click.echo") as echo:
+        display_notebook_help(click_context, str(name))
+        print(echo.call_args_list)
+        assert echo.call_count == len(expected)
+        for call, target in zip(echo.call_args_list, expected):
+            assert call[0][0] == target.format(name=str(name))

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from papermill.iorw import load_notebook_node
+
+
+NOTEBOOKS_PATH = Path(__file__).parent / "notebooks"
+
+
+def _get_fullpath(name):
+    return NOTEBOOKS_PATH / name
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (_get_fullpath("no_parameters.ipynb"), {}),
+        (
+            _get_fullpath("simple_execute.ipynb"),
+            {"msg": {"name": "msg", "inferred_type_name": "None", "default": "None", "help": ""}},
+        ),
+        (
+            _get_fullpath("complex_parameters.ipynb"),
+            {
+                "msg": {"name": "msg", "inferred_type_name": "None", "default": "None", "help": ""},
+                "a": {
+                    "name": "a",
+                    "inferred_type_name": "float",
+                    "default": "2.25",
+                    "help": "Variable a",
+                },
+                "b": {
+                    "name": "b",
+                    "inferred_type_name": "List[str]",
+                    "default": "['Hello','World']",
+                    "help": "Nice list",
+                },
+                "c": {"name": "c", "inferred_type_name": "NoneType", "default": "None", "help": ""},
+            },
+        ),
+        (_get_fullpath("notimplemented_translator.ipynb"), {}),
+    ],
+)
+def test_default_parameters(name, expected):
+    nb = load_notebook_node(str(name))
+
+    assert nb.metadata['papermill']['default_parameters'] == expected

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -4,8 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click import Context
 
-from papermill.iorw import load_notebook_node
-from papermill.inspection import display_notebook_help
+from papermill.inspection import display_notebook_help, inspect_notebook
 
 
 NOTEBOOKS_PATH = Path(__file__).parent / "notebooks"
@@ -52,10 +51,8 @@ def click_context():
         (_get_fullpath("notimplemented_translator.ipynb"), {}),
     ],
 )
-def test_default_parameters(name, expected):
-    nb = load_notebook_node(str(name))
-
-    assert nb.metadata['papermill']['default_parameters'] == expected
+def test_inspect_notebook(name, expected):
+    assert inspect_notebook(str(name)) == expected
 
 
 @pytest.mark.parametrize(
@@ -65,7 +62,7 @@ def test_default_parameters(name, expected):
             _get_fullpath("no_parameters.ipynb"),
             [
                 "Dummy usage",
-                "\n  Parameters inferred for notebook '{name}':",
+                "\nParameters inferred for notebook '{name}':",
                 "\n  No cell tagged 'parameters'",
             ],
         ),
@@ -73,26 +70,26 @@ def test_default_parameters(name, expected):
             _get_fullpath("simple_execute.ipynb"),
             [
                 "Dummy usage",
-                "\n  Parameters inferred for notebook '{name}':",
-                "     msg: Unknown type (default None)\t\t",
+                "\nParameters inferred for notebook '{name}':",
+                "  msg: Unknown type (default None)",
             ],
         ),
         (
             _get_fullpath("complex_parameters.ipynb"),
             [
                 "Dummy usage",
-                "\n  Parameters inferred for notebook '{name}':",
-                "     msg: Unknown type (default None)\t\t",
-                "     a: float (default 2.25)\t\tVariable a",
-                "     b: List[str] (default ['Hello','World'])\t\tNice list",
-                "     c: NoneType (default None)\t\t",
+                "\nParameters inferred for notebook '{name}':",
+                "  msg: Unknown type (default None)",
+                "  a: float (default 2.25)         Variable a",
+                "  b: List[str] (default ['Hello','World'])\n                                  Nice list",  # noqa
+                "  c: NoneType (default None)      ",
             ],
         ),
         (
             _get_fullpath("notimplemented_translator.ipynb"),
             [
                 "Dummy usage",
-                "\n  Parameters inferred for notebook '{name}':",
+                "\nParameters inferred for notebook '{name}':",
                 "\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.",  # noqa
             ],
         ),
@@ -100,8 +97,8 @@ def test_default_parameters(name, expected):
 )
 def test_display_notebook_help(click_context, name, expected):
     with patch("papermill.inspection.click.echo") as echo:
-        display_notebook_help(click_context, str(name))
-        print(echo.call_args_list)
+        display_notebook_help(click_context, str(name), None)
+
         assert echo.call_count == len(expected)
         for call, target in zip(echo.call_args_list, expected):
             assert call[0][0] == target.format(name=str(name))

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -3,8 +3,11 @@ import pytest
 from unittest.mock import Mock
 from collections import OrderedDict
 
+from nbformat.v4 import new_code_cell
+
 from .. import translators
 from ..exceptions import PapermillException
+from ..inspection import Parameter
 
 
 @pytest.mark.parametrize(
@@ -62,6 +65,41 @@ def test_translate_codify_python(parameters, expected):
 def test_translate_comment_python(test_input, expected):
     assert translators.PythonTranslator.comment(test_input) == expected
 
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("a = 2", [Parameter("a", "None", "2", "")]),
+        ("a: int = 2", [Parameter("a", "int", "2", "")]),
+        ("a = 2 # type:int", [Parameter("a", "int", "2", "")]),
+        ("a = False # Nice variable a", [Parameter("a", "None", "False", "Nice variable a")]),
+        ("a: float = 2.258 # type: int Nice variable a", [Parameter("a", "float", "2.258", "Nice variable a")]),
+        ("a = 'this is a string' # type: int Nice variable a", [Parameter("a", "int", "'this is a string'", "Nice variable a")]),
+        ("a: List[str] = ['this', 'is', 'a', 'string', 'list'] # Nice variable a", [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")]),
+        ("a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a", [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]),
+        ("a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a", [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]),
+        (
+            """a: List[str] = [
+                'this', # First
+                'is',
+
+                'a',
+                'string',
+                'list' # Last
+            ] # Nice variable a
+
+            b: float = -2.3432 # My b variable
+            """, 
+            [
+                Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a"),
+                Parameter("b", "float", "-2.3432", "My b variable"),
+            ]
+        ),
+    ]
+)
+def test_inspect_python(test_input, expected):
+    cell = new_code_cell(source=test_input)
+    assert translators.PythonTranslator.inspect(cell) == expected
 
 @pytest.mark.parametrize(
     "test_input,expected",

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -7,7 +7,7 @@ from nbformat.v4 import new_code_cell
 
 from .. import translators
 from ..exceptions import PapermillException
-from ..inspection import Parameter
+from ..models import Parameter
 
 
 @pytest.mark.parametrize(

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -73,7 +73,7 @@ def test_translate_comment_python(test_input, expected):
         ("a: int = 2", [Parameter("a", "int", "2", "")]),
         ("a = 2 # type:int", [Parameter("a", "int", "2", "")]),
         ("a = False # Nice variable a", [Parameter("a", "None", "False", "Nice variable a")]),
-        ("a: float = 2.258 # type: int Nice variable a", [Parameter("a", "float", "2.258", "Nice variable a")]),
+        ("a: float = 2.258 # type: int Nice variable a", [Parameter("a", "float", "2.258", "Nice variable a")]),  # noqa
         (
             "a = 'this is a string' # type: int Nice variable a",
             [Parameter("a", "int", "'this is a string'", "Nice variable a")]
@@ -83,11 +83,11 @@ def test_translate_comment_python(test_input, expected):
             [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")]
         ),
         (
-            "a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a", # noqa
+            "a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a",  # noqa
             [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
         ),
         (
-            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",
+            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",  # noqa
             [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
         ),
         (

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -74,10 +74,22 @@ def test_translate_comment_python(test_input, expected):
         ("a = 2 # type:int", [Parameter("a", "int", "2", "")]),
         ("a = False # Nice variable a", [Parameter("a", "None", "False", "Nice variable a")]),
         ("a: float = 2.258 # type: int Nice variable a", [Parameter("a", "float", "2.258", "Nice variable a")]),
-        ("a = 'this is a string' # type: int Nice variable a", [Parameter("a", "int", "'this is a string'", "Nice variable a")]),
-        ("a: List[str] = ['this', 'is', 'a', 'string', 'list'] # Nice variable a", [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")]),
-        ("a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a", [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]),
-        ("a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a", [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]),
+        (
+            "a = 'this is a string' # type: int Nice variable a",
+            [Parameter("a", "int", "'this is a string'", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = ['this', 'is', 'a', 'string', 'list'] # Nice variable a",
+            [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a", # noqa
+            [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",
+            [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
+        ),
         (
             """a: List[str] = [
                 'this', # First
@@ -89,7 +101,7 @@ def test_translate_comment_python(test_input, expected):
             ] # Nice variable a
 
             b: float = -2.3432 # My b variable
-            """, 
+            """,
             [
                 Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a"),
                 Parameter("b", "float", "-2.3432", "My b variable"),
@@ -100,6 +112,7 @@ def test_translate_comment_python(test_input, expected):
 def test_inspect_python(test_input, expected):
     cell = new_code_cell(source=test_input)
     assert translators.PythonTranslator.inspect(cell) == expected
+
 
 @pytest.mark.parametrize(
     "test_input,expected",

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -5,8 +5,26 @@ import warnings
 from unittest.mock import Mock, call
 from tempfile import TemporaryDirectory
 
-from ..utils import retry, chdir, merge_kwargs, remove_args
+from nbformat.v4 import new_notebook, new_code_cell
+
+from ..utils import (
+    any_tagged_cell,
+    retry,
+    chdir,
+    merge_kwargs,
+    remove_args,
+)
 from ..exceptions import PapermillParameterOverwriteWarning
+
+
+def test_no_tagged_cell():
+    nb = new_notebook(cells=[new_code_cell('a = 2', metadata={"tags": []})],)
+    assert not any_tagged_cell(nb, "parameters")
+
+
+def test_tagged_cell():
+    nb = new_notebook(cells=[new_code_cell('a = 2', metadata={"tags": ["parameters"]})],)
+    assert any_tagged_cell(nb, "parameters")
 
 
 def test_merge_kwargs():

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -251,7 +251,6 @@ class PythonTranslator(Translator):
         grouped_variable.append(flatten_accumulator(accumulator))
 
         for definition in grouped_variable:
-            print(definition)
             if len(definition) == 0:
                 continue
 

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -236,8 +236,8 @@ class PythonTranslator(Translator):
         grouped_variable = []
         accumulator = []
         for iline, line in enumerate(src.splitlines()):
-            if len(line.strip()) == 0:
-                continue  # Skip blank line
+            if len(line.strip()) == 0 or line.strip().startswith('#'):
+                continue  # Skip blank and comment
 
             nequal = line.count("=")
             if nequal > 0:

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -147,7 +147,7 @@ class Translator(object):
 class PythonTranslator(Translator):
     # Pattern to capture parameters within cell input
     PARAMETER_PATTERN = re.compile(
-        r"^(?P<target>\w[\w_]*)\s*(:\s*(?P<annotation>\w[\w_\[\],\s]*))?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"  # noqa
+        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"  # noqa
     )
 
     @classmethod
@@ -251,6 +251,7 @@ class PythonTranslator(Translator):
         grouped_variable.append(flatten_accumulator(accumulator))
 
         for definition in grouped_variable:
+            print(definition)
             if len(definition) == 0:
                 continue
 

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -142,7 +142,7 @@ class Translator(object):
         List[Parameter]
             A list of all parameters
         """
-        return list()
+        raise NotImplementedError('parameters introspection not implemented for {}'.format(cls))
 
 
 class PythonTranslator(Translator):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import math
 import re
@@ -124,7 +123,7 @@ class Translator(object):
     @classmethod
     def inspect(cls, parameters_cell):
         """Inspect the parameters cell to get a Parameter list
-        
+
         It must return an empty list if no parameters are found and
         it should ignore inspection errors.
 
@@ -136,7 +135,7 @@ class Translator(object):
         ----------
         parameters_cell : NotebookNode
             Cell tagged _parameters_
-        
+
         Returns
         -------
         List[Parameter]
@@ -148,7 +147,7 @@ class Translator(object):
 class PythonTranslator(Translator):
     # Pattern to capture parameters within cell input
     PARAMETER_PATTERN = re.compile(
-        r"^(?P<target>\w[\w_]*)\s*(:\s*(?P<annotation>\w[\w_\[\],\s]*))?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
+        r"^(?P<target>\w[\w_]*)\s*(:\s*(?P<annotation>\w[\w_\[\],\s]*))?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"  # noqa
     )
 
     @classmethod
@@ -196,7 +195,7 @@ class PythonTranslator(Translator):
     @classmethod
     def inspect(cls, parameters_cell):
         """Inspect the parameters cell to get a Parameter list
-        
+
         It must return an empty list if no parameters are found and
         it should ignore inspection errors.
 
@@ -204,7 +203,7 @@ class PythonTranslator(Translator):
         ----------
         parameters_cell : NotebookNode
             Cell tagged _parameters_
-        
+
         Returns
         -------
         List[Parameter]
@@ -215,7 +214,7 @@ class PythonTranslator(Translator):
 
         def flatten_accumulator(accumulator):
             """Flatten a multilines variable definition.
-            
+
             Remove all comments except on the latest line - will be interpreted as help.
 
             Args:
@@ -247,14 +246,14 @@ class PythonTranslator(Translator):
                 if nequal > 1:
                     logger.warning("Unable to parse line {} '{}'.".format(iline + 1, line))
                     continue
-            
+
             accumulator.append(line)
         grouped_variable.append(flatten_accumulator(accumulator))
-            
+
         for definition in grouped_variable:
             if len(definition) == 0:
                 continue
-            
+
             match = re.match(cls.PARAMETER_PATTERN, definition)
             if match is not None:
                 attr = match.groupdict()
@@ -268,7 +267,7 @@ class PythonTranslator(Translator):
                     default=str(attr["value"]).strip(),
                     help=str(attr["help"] or "").strip()
                 ))
-                
+
         return params
 
 

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,7 +1,14 @@
+import ast
+import logging
 import math
+import re
 import sys
 
 from .exceptions import PapermillException
+from .models import Parameter
+
+
+logger = logging.getLogger(__name__)
 
 
 class PapermillTranslators(object):
@@ -114,8 +121,36 @@ class Translator(object):
             content += '{}\n'.format(cls.assign(name, cls.translate(val)))
         return content
 
+    @classmethod
+    def inspect(cls, parameters_cell):
+        """Inspect the parameters cell to get a Parameter list
+        
+        It must return an empty list if no parameters are found and
+        it should ignore inspection errors.
+
+        .. note::
+            ``inferred_type_name`` should be "None" if unknown (set it
+            to "NoneType" for null value)
+
+        Parameters
+        ----------
+        parameters_cell : NotebookNode
+            Cell tagged _parameters_
+        
+        Returns
+        -------
+        List[Parameter]
+            A list of all parameters
+        """
+        return list()
+
 
 class PythonTranslator(Translator):
+    # Pattern to capture parameters within cell input
+    PARAMETER_PATTERN = re.compile(
+        r"^(?P<target>\w[\w_]*)\s*(:\s*(?P<annotation>\w[\w_\[\],\s]*))?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
+    )
+
     @classmethod
     def translate_float(cls, val):
         if math.isfinite(val):
@@ -157,6 +192,84 @@ class PythonTranslator(Translator):
             fm = black.FileMode(string_normalization=False)
             content = black.format_str(content, mode=fm)
         return content
+
+    @classmethod
+    def inspect(cls, parameters_cell):
+        """Inspect the parameters cell to get a Parameter list
+        
+        It must return an empty list if no parameters are found and
+        it should ignore inspection errors.
+
+        Parameters
+        ----------
+        parameters_cell : NotebookNode
+            Cell tagged _parameters_
+        
+        Returns
+        -------
+        List[Parameter]
+            A list of all parameters
+        """
+        params = []
+        src = parameters_cell['source']
+
+        def flatten_accumulator(accumulator):
+            """Flatten a multilines variable definition.
+            
+            Remove all comments except on the latest line - will be interpreted as help.
+
+            Args:
+                accumulator (List[str]): Line composing the variable definition
+            Returns:
+                Flatten definition
+            """
+            flat_string = ""
+            for line in accumulator[:-1]:
+                if "#" in line:
+                    comment_pos = line.index("#")
+                    flat_string += line[:comment_pos].strip()
+                else:
+                    flat_string += line.strip()
+            if len(accumulator):
+                flat_string += accumulator[-1].strip()
+            return flat_string
+
+        grouped_variable = []
+        accumulator = []
+        for iline, line in enumerate(src.splitlines()):
+            if len(line.strip()) == 0:
+                continue  # Skip blank line
+
+            nequal = line.count("=")
+            if nequal > 0:
+                grouped_variable.append(flatten_accumulator(accumulator))
+                accumulator = []
+                if nequal > 1:
+                    logger.warning("Unable to parse line {} '{}'.".format(iline + 1, line))
+                    continue
+            
+            accumulator.append(line)
+        grouped_variable.append(flatten_accumulator(accumulator))
+            
+        for definition in grouped_variable:
+            if len(definition) == 0:
+                continue
+            
+            match = re.match(cls.PARAMETER_PATTERN, definition)
+            if match is not None:
+                attr = match.groupdict()
+                if attr["target"] is None:  # Fail to get variable name
+                    continue
+
+                type_name = str(attr["annotation"] or attr["type_comment"] or None)
+                params.append(Parameter(
+                    name=attr["target"].strip(),
+                    inferred_type_name=type_name.strip(),
+                    default=str(attr["value"]).strip(),
+                    help=str(attr["help"] or "").strip()
+                ))
+                
+        return params
 
 
 class RTranslator(Translator):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -233,6 +233,11 @@ class PythonTranslator(Translator):
                 flat_string += accumulator[-1].strip()
             return flat_string
 
+        # Some common type like dictionaries or list can be expressed over multiline.
+        # To support the parsing of such case, the cell lines are grouped between line
+        # actually containing an assignment. In each group, the commented and empty lines
+        # are skip; i.e. the parameter help can only be given as comment on the last variable
+        # line definition
         grouped_variable = []
         accumulator = []
         for iline, line in enumerate(src.splitlines()):
@@ -261,12 +266,14 @@ class PythonTranslator(Translator):
                     continue
 
                 type_name = str(attr["annotation"] or attr["type_comment"] or None)
-                params.append(Parameter(
-                    name=attr["target"].strip(),
-                    inferred_type_name=type_name.strip(),
-                    default=str(attr["value"]).strip(),
-                    help=str(attr["help"] or "").strip()
-                ))
+                params.append(
+                    Parameter(
+                        name=attr["target"].strip(),
+                        inferred_type_name=type_name.strip(),
+                        default=str(attr["value"]).strip(),
+                        help=str(attr["help"] or "").strip(),
+                    )
+                )
 
         return params
 

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -10,6 +10,48 @@ from .exceptions import PapermillParameterOverwriteWarning
 logger = logging.getLogger('papermill.utils')
 
 
+def any_tagged_cell(nb, tag):
+    """Whether the notebook contains at least one cell tagged ``tag``?
+    
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    tag : str
+        The tag to look for
+
+    Returns
+    -------
+    bool
+        Whether the notebook contains a cell tagged ``tag``?
+    """
+    return any([tag in cell.metadata.tags for cell in nb.cells])
+
+
+def find_first_tagged_cell_index(nb, tag):
+    """Find the first tagged cell ``tag`` in the notebook.
+    
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    tag : str
+        The tag to look for
+
+    Returns
+    -------
+    nbformat.NotebookNode
+        Whether the notebook contains a cell tagged ``tag``?
+    """
+    parameters_indices = []
+    for idx, cell in enumerate(nb.cells):
+        if tag in cell.metadata.tags:
+            parameters_indices.append(idx)
+    if not parameters_indices:
+        return -1
+    return parameters_indices[0]
+
+
 def merge_kwargs(caller_args, **callee_args):
     """Merge named argument.
 

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -12,7 +12,7 @@ logger = logging.getLogger('papermill.utils')
 
 def any_tagged_cell(nb, tag):
     """Whether the notebook contains at least one cell tagged ``tag``?
-    
+
     Parameters
     ----------
     nb : nbformat.NotebookNode
@@ -30,7 +30,7 @@ def any_tagged_cell(nb, tag):
 
 def find_first_tagged_cell_index(nb, tag):
     """Find the first tagged cell ``tag`` in the notebook.
-    
+
     Parameters
     ----------
     nb : nbformat.NotebookNode

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-azure-datalake-store >= 0.0.30
-azure-storage-blob >= 12.1.0
 boto3
 botocore
 codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,23 @@
+azure-datalake-store >= 0.0.30
+azure-storage-blob >= 12.1.0
+boto3
+botocore
 codecov
 coverage
+google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
+ipython>=5.0
+ipywidgets
 notebook
 mock
+moto
 pytest>=4.1
 pytest-cov>=2.6.1
 pytest-mock>=1.10
 pytest-env>=0.6.2
-ipython>=5.0
-moto
+requests >= 2.21.0
 check-manifest
 attrs>=17.4.0
 pre-commit
-boto3
-botocore
-ipywidgets
 flake8
 tox
 bumpversion
@@ -22,4 +26,3 @@ pip>=18.1
 wheel>=0.31.0
 setuptools>=38.6.0
 twine>=1.11.0
-google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there


### PR DESCRIPTION
This is a reboot of #158 

It adds a new option `--help-notebook` to create a new cli usage:

```
papermill --help-notebook input_notebook.ipynb
```
Due to that I had to remove the `required` statement on OUTPUT_PATH. But the test is still done within the `papermill` function to keep the behavior if `--help-notebook` is not set.

Fixes #225 => in particular the default parameters resulting of the code introspection are added as a dictionary in metadata `nb.metadata['papermill']['default_parameters']`.

For now this add the ability for Python. I'm not familiar to the other languages to build the proper regex.

> Note: I use a regex instead of `ast` for Python for two reasons: `ast` removes all comments but I use them to get a help comment. ast parsing for non-python language won't be available. So it seems better to use regex for all languages.

A follow up could be to address #55, but there is a important issue on how to fairly evaluate the variable type for non-python language.