### PR TITLE
Support empty YAML configuration 

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -223,11 +223,11 @@ def papermill(
     if inject_output_path or inject_paths:
         parameters_final['PAPERMILL_OUTPUT_PATH'] = output_path
     for params in parameters_base64 or []:
-        parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader))
+        parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader) or {})
     for files in parameters_file or []:
-        parameters_final.update(read_yaml_file(files))
+        parameters_final.update(read_yaml_file(files) or {})
     for params in parameters_yaml or []:
-        parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
+        parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader) or {})
     for name, value in parameters or []:
         parameters_final[name] = _resolve_type(value)
     for name, value in parameters_raw or []:

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -3,8 +3,10 @@
 """ Test the command line interface """
 
 import os
+from pathlib import Path
 import sys
 import subprocess
+import tempfile
 import uuid
 import nbclient
 
@@ -166,6 +168,31 @@ class TestCLI(unittest.TestCase):
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'})
         )
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_empty(self, execute_patch):
+        # "#empty" ---base64--> "I2VtcHR5"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_yaml = Path(tmpdir) / 'empty.yaml'
+            empty_yaml.write_text('#empty')
+            self.runner.invoke(
+                papermill,
+                self.default_args
+                + [
+                    '--parameters_file',
+                    str(empty_yaml),
+                    '--parameters_yaml',
+                    '#empty',
+                    '--parameters_base64',
+                    'I2VtcHR5',
+                ],
+            )
+            execute_patch.assert_called_with(
+                **self.augment_execute_kwargs(
+                    # should be empty
+                    parameters={}
+                )
+            )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_yaml_override(self, execute_patch):


### PR DESCRIPTION
Fix #558 
Prevent `TypeError: 'NoneType' object is not iterable` exception when using empty (or with comments only) YAML file in CLI

Based on changes suggested by @dhorgan.
```
...
parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader) or {})
...
parameters_final.update(read_yaml_file(files) or {})
...
parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader) or {})
...
```

Also add single test `test_parameters_empty` in `test_cli.py` instead of creating a separate test for "-f", "-y" and "-b" 