### PR TITLE
Added cell description to tqdm

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -212,6 +212,11 @@ class NotebookExecutionManager(object):
         cell.metadata.papermill['start_time'] = self.now().isoformat()
         cell.metadata.papermill["status"] = self.RUNNING
         cell.metadata.papermill['exception'] = False
+        
+        # injects optional description of the current cell directly in the tqdm 
+        cell_description = self.get_cell_description(cell)
+        if cell_description is not None and hasattr(self, 'pbar') and self.pbar:
+            self.pbar.set_description(f"Executing {cell_description}")
 
         self.save()
 
@@ -283,6 +288,17 @@ class NotebookExecutionManager(object):
 
         # Force a final sync
         self.save()
+        
+    def get_cell_description(self, cell, escape_str="papermill_description="):
+        """Fetches cell description if present"""
+        if cell is None: return None
+        
+        cell_code = cell["source"]
+        if cell_code is None or escape_str not in cell_code:
+            return None
+        
+        description=cell_code.split(escape_str)[1].split()[0]
+        return description
 
     def complete_pbar(self):
         """Refresh progress bar"""

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -212,7 +212,7 @@ class NotebookExecutionManager(object):
         cell.metadata.papermill['start_time'] = self.now().isoformat()
         cell.metadata.papermill["status"] = self.RUNNING
         cell.metadata.papermill['exception'] = False
-        
+
         # injects optional description of the current cell directly in the tqdm
         cell_description = self.get_cell_description(cell)
         if cell_description is not None and hasattr(self, 'pbar') and self.pbar:
@@ -288,16 +288,16 @@ class NotebookExecutionManager(object):
 
         # Force a final sync
         self.save()
-        
+
     def get_cell_description(self, cell, escape_str="papermill_description="):
         """Fetches cell description if present"""
         if cell is None:
             return None
-        
+
         cell_code = cell["source"]
         if cell_code is None or escape_str not in cell_code:
             return None
-        
+
         return cell_code.split(escape_str)[1].split()[0]
 
     def complete_pbar(self):

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -213,7 +213,7 @@ class NotebookExecutionManager(object):
         cell.metadata.papermill["status"] = self.RUNNING
         cell.metadata.papermill['exception'] = False
         
-        # injects optional description of the current cell directly in the tqdm 
+        # injects optional description of the current cell directly in the tqdm
         cell_description = self.get_cell_description(cell)
         if cell_description is not None and hasattr(self, 'pbar') and self.pbar:
             self.pbar.set_description(f"Executing {cell_description}")
@@ -297,8 +297,7 @@ class NotebookExecutionManager(object):
         if cell_code is None or escape_str not in cell_code:
             return None
         
-        description=cell_code.split(escape_str)[1].split()[0]
-        return description
+        return cell_code.split(escape_str)[1].split()[0]
 
     def complete_pbar(self):
         """Refresh progress bar"""

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -291,7 +291,8 @@ class NotebookExecutionManager(object):
         
     def get_cell_description(self, cell, escape_str="papermill_description="):
         """Fetches cell description if present"""
-        if cell is None: return None
+        if cell is None:
+            return None
         
         cell_code = cell["source"]
         if cell_code is None or escape_str not in cell_code:

--- a/papermill/tests/notebooks/simple_execute.ipynb
+++ b/papermill/tests/notebooks/simple_execute.ipynb
@@ -19,6 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#papermill_description=DESC\n",
     "print(msg)"
    ]
   },
@@ -46,9 +47,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -81,10 +81,15 @@ class TestNotebookExecutionManager(unittest.TestCase):
         nb_man = NotebookExecutionManager(self.nb)
         nb_man.save(nb=self.foo_nb)
         self.assertEqual(nb_man.nb.metadata['foo'], 'bar')
-
+    
+    def test_get_cell_description(self):
+        nb_man = NotebookExecutionManager(self.nb)
+        self.assertIsNone(nb_man.get_cell_description(nb_man.nb.cells[0]))
+        self.assertEqual(nb_man.get_cell_description(nb_man.nb.cells[1]), 'DESC')
+        
     def test_notebook_start(self):
         nb_man = NotebookExecutionManager(self.nb)
-        nb_man.save = Mock()
+        nb_man.nb_path.metadata['foo'] = 'bar'
         nb_man.notebook_start()
 
         self.assertEqual(nb_man.nb.metadata.papermill['start_time'], nb_man.start_time.isoformat())


### PR DESCRIPTION
Added possibility to set description of cells that will be injected to the tqdm.
To add description to a specific cell the user must add a string with this formatting in the desired cell:
`# papermill_description=description_of_cell`
When the execution will reach that cell, the description of the tqdm will be changed from `Executing x:` to `Executing description_of_cell`. 
If no cell contains the tag `papermill_description=`, the execution will be as before the implementation of this functionality.
If a cell containing the description tag is followed by cells that don't have the tag, the tqdm description is set to the last valid description.

I decided to implement this functionality because I think it is pretty useful with long notebooks that have very slow cells (i.e. data preparation and model training). An alternative can be to use logging, but it is way more verbose.
With this implementation you can simply add the 'Training' description to a cell and you know you are in the training process, or you can add 'Data_Preparation' and you know you are doing data preparation, moreover you see only the description of the current cell in the tqdm.
If a user doesn't like this functionality, he can simply ignore it.

I think it would be a good idea to add information about this feature in the documentation, but I would like to know first if this this is correctly implemented and perceived as a good addition from the authors/contributors.
