### PR TITLE
Fix #568 (unexpected id field)

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -408,6 +408,9 @@ def load_notebook_node(notebook_path):
 
     """
     nb = nbformat.reads(papermill_io.read(notebook_path), as_version=4)
+    nb_upgraded = nbformat.v4.upgrade(nb)
+    if nb_upgraded is not None:
+        nb = nb_upgraded
 
     if not hasattr(nb.metadata, 'papermill'):
         nb.metadata['papermill'] = {

--- a/papermill/tests/notebooks/nb_version_4.4.ipynb
+++ b/papermill/tests/notebooks/nb_version_4.4.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "var = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(var)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -7,6 +7,8 @@ import unittest
 from functools import partial
 from pathlib import Path
 
+from nbformat import validate
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -355,3 +357,18 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
         self.assertEqual(nb.cells[1].outputs[0].evalue, '')
         self.assertEqual(nb.cells[2].execution_count, None)
+
+
+class TestNotebookValidation(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_from_version_4_4_upgrades(self):
+        notebook_name = 'nb_version_4.4.ipynb'
+        result_path = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
+        nb = load_notebook_node(result_path)
+        validate(nb)


### PR DESCRIPTION
Fix issue #568.

An upgrade is performed after loading the notebook, so Papermill should always work internally with a notebook with the latest version.