### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
-sudo: false
-matrix:
+dist: xenial
+os: linux
+jobs:
   include:
-    - python: 3.6
+    - python: 3.6.12
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37


### PR DESCRIPTION
Fix travis build for 3.6
- bump version of python to 3.6.12 to fix missing rust compiler
- update the configuration parameters to meet current travis recommendation