### PR TITLE
Added language field and fixed language fetch for v4 spec

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -100,8 +100,16 @@ def print_papermill_version(ctx, param, value):
     default=False,
     help="Flag for outputting the notebook without execution, but with parameters applied.",
 )
-@click.option('--kernel', '-k', help='Name of kernel to run. Ignores kernel name in the notebook document.')
-@click.option('--language', '-l', help='Language override of notebook. Ignores language in the notebook document.')
+@click.option(
+    '--kernel',
+    '-k',
+    help='Name of kernel to run. Ignores kernel name in the notebook document.'
+)
+@click.option(
+    '--language',
+    '-l',
+    help='Language override of notebook. Ignores language in the notebook document.'
+)
 @click.option('--cwd', default=None, help='Working directory to run notebook in.')
 @click.option(
     '--progress-bar/--no-progress-bar', default=None, help="Flag for turning on the progress bar."

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -100,7 +100,8 @@ def print_papermill_version(ctx, param, value):
     default=False,
     help="Flag for outputting the notebook without execution, but with parameters applied.",
 )
-@click.option('--kernel', '-k', help='Name of kernel to run.')
+@click.option('--kernel', '-k', help='Name of kernel to run. Ignores kernel name in the notebook document.')
+@click.option('--language', '-l', help='Language override of notebook. Ignores language in the notebook document.')
 @click.option('--cwd', default=None, help='Working directory to run notebook in.')
 @click.option(
     '--progress-bar/--no-progress-bar', default=None, help="Flag for turning on the progress bar."
@@ -165,6 +166,7 @@ def papermill(
     autosave_cell_every,
     prepare_only,
     kernel,
+    language,
     cwd,
     progress_bar,
     log_output,
@@ -246,6 +248,7 @@ def papermill(
             autosave_cell_every=autosave_cell_every,
             prepare_only=prepare_only,
             kernel_name=kernel,
+            language=language,
             progress_bar=progress_bar,
             log_output=log_output,
             stdout_file=stdout_file,

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -103,12 +103,12 @@ def print_papermill_version(ctx, param, value):
 @click.option(
     '--kernel',
     '-k',
-    help='Name of kernel to run. Ignores kernel name in the notebook document.'
+    help='Name of kernel to run. Ignores kernel name in the notebook document metadata.'
 )
 @click.option(
     '--language',
     '-l',
-    help='Language override of notebook. Ignores language in the notebook document.'
+    help='Language for notebook execution. Ignores language in the notebook document metadata.'
 )
 @click.option('--cwd', default=None, help='Working directory to run notebook in.')
 @click.option(

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -50,7 +50,7 @@ def execute_notebook(
         Flag to determine if execution should occur or not
     kernel_name : str, optional
         Name of kernel to execute the notebook against
-    languages : str, optional
+    language : str, optional
         Programming language of the notebook
     progress_bar : bool, optional
         Flag for whether or not to show the progress bar.

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -91,8 +91,9 @@ def execute_notebook(
 
         # Parameterize the Notebook.
         if parameters:
-            nb = parameterize_notebook(nb, parameters, report_mode,
-            kernel_name=kernel_name, language=language)
+            nb = parameterize_notebook(
+                nb, parameters, report_mode, kernel_name=kernel_name, language=language
+            )
 
         nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode)
         # clear out any existing error markers from previous papermill runs

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -5,7 +5,7 @@ from .log import logger
 from .exceptions import PapermillMissingParameterException
 from .iorw import read_yaml_file
 from .translators import translate_parameters
-from .utils import find_first_tagged_cell_index
+from .utils import find_first_tagged_cell_index, nb_kernel_name, nb_language
 
 from uuid import uuid4
 from datetime import datetime
@@ -52,7 +52,8 @@ def parameterize_path(path, parameters):
         raise PapermillMissingParameterException("Missing parameter {}".format(key_error))
 
 
-def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters'):
+def parameterize_notebook(nb, parameters,
+        report_mode=False, comment='Parameters', kernel_name=None, language=None):
     """Assigned parameters into the appropriate place in the input notebook
 
     Parameters
@@ -73,8 +74,9 @@ def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters
     # Copy the nb object to avoid polluting the input
     nb = copy.deepcopy(nb)
 
-    kernel_name = nb.metadata.kernelspec.name
-    language = nb.metadata.kernelspec.language
+    # Fetch out the name and language from the notebook document
+    kernel_name = nb_kernel_name(nb, kernel_name)
+    language = nb_language(nb, language)
 
     # Generate parameter content based on the kernel_name
     param_content = translate_parameters(kernel_name, language, parameters, comment)

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -52,8 +52,9 @@ def parameterize_path(path, parameters):
         raise PapermillMissingParameterException("Missing parameter {}".format(key_error))
 
 
-def parameterize_notebook(nb, parameters,
-        report_mode=False, comment='Parameters', kernel_name=None, language=None):
+def parameterize_notebook(
+    nb, parameters, report_mode=False, comment='Parameters', kernel_name=None, language=None
+):
     """Assigned parameters into the appropriate place in the input notebook
 
     Parameters

--- a/papermill/tests/notebooks/blank-vscode.ipynb
+++ b/papermill/tests/notebooks/blank-vscode.ipynb
@@ -1,0 +1,28 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": 3
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -86,6 +86,7 @@ class TestCLI(unittest.TestCase):
         autosave_cell_every=30,
         prepare_only=False,
         kernel_name=None,
+        language=None,
         log_output=False,
         progress_bar=True,
         start_timeout=60,
@@ -283,6 +284,11 @@ class TestCLI(unittest.TestCase):
     def test_kernel(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-k', 'python3'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(kernel_name='python3'))
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_language(self, execute_patch):
+        self.runner.invoke(papermill, self.default_args + ['-l', 'python'])
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(language='python'))
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_set_cwd(self, execute_patch):

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -372,3 +372,18 @@ class TestNotebookValidation(unittest.TestCase):
         execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
         nb = load_notebook_node(result_path)
         validate(nb)
+
+
+class TestMinimalNotebook(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_no_v3_language_backport(self):
+        notebook_name = 'blank-vscode.ipynb'
+        result_path = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
+        nb = load_notebook_node(result_path)
+        validate(nb)

--- a/papermill/tests/test_s3.py
+++ b/papermill/tests/test_s3.py
@@ -161,7 +161,7 @@ test_clean_nb_content = no_empty_lines(test_nb_content)
 read_from_gen = lambda g: "\n".join(g)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def s3_client():
     mock_s3 = moto.mock_s3()
     mock_s3.start()

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -28,6 +28,61 @@ def any_tagged_cell(nb, tag):
     return any([tag in cell.metadata.tags for cell in nb.cells])
 
 
+def nb_kernel_name(nb, name=None):
+    """Helper for fetching out the kernel name from a notebook object.
+
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    name : str
+        A provided name field
+
+    Returns
+    -------
+    str
+        The name of the kernel
+
+    Raises
+    ------
+    ValueError
+        If no kernel name is found or provided
+    """
+    name = name or nb.metadata.get('kernelspec', {}).get('name')
+    if not name:
+        raise ValueError("No kernel name found in notebook and no override provided.")
+    return name
+
+
+def nb_language(nb, language=None):
+    """Helper for fetching out the programming language from a notebook object.
+
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    language : str
+        A provided language field
+
+    Returns
+    -------
+    str
+        The programming language of the notebook
+
+    Raises
+    ------
+    ValueError
+        If no notebook language is found or provided
+    """
+    language = language or nb.metadata.get('language_info', {}).get('name')
+    if not language:
+        # v3 language path for old notebooks that didn't convert cleanly
+        language = language or nb.metadata.get('kernelspec', {}).get('language')
+    if not language:
+        raise ValueError("No language found in notebook and no override provided.")
+    return language
+
+
 def find_first_tagged_cell_index(nb, tag):
     """Find the first tagged cell ``tag`` in the notebook.
 


### PR DESCRIPTION
Resolves https://github.com/nteract/papermill/issues/581

Adds a language option to the CLI to overwrite the notebook language (or supply one if a file was invalid / not parsing correctly).
Fixes the language fetch from the document to first look in the v4 path, than the v3 path for the notebook language. Apparently every tool was publishing to both places except VSCode which only uses the v4 location and we never caught it before.