### PR TITLE
Set minimum version for black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ tqdm >= 4.32.2
 requests
 entrypoints
 tenacity
-black
+black >= 19.3b0


### PR DESCRIPTION
https://github.com/nteract/papermill/blob/main/papermill/translators.py#L191  relies on `FileMode` to include a `string_normalization` parameter. This was introduced in 
https://github.com/psf/black/commit/36d3c516d3c09fc5f05c420900dd6b854e3c8bbd#diff-fe0a71b8c720ce9ae962aaa7a1bdc63f30bc8eff585cf25e466cd33306c5a042R108. Explicitly setting this constraint would avoid unnecessary troubleshooting.