### PR TITLE
Updated file read to not fail early with a boto empty file exception

### DIFF
--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -304,6 +304,12 @@ class S3(object):
                 elif size != obj.content_length:
                     raise AwsError('key size unexpectedly changed while reading')
 
+                # For an empty file, 0 (first-bytes-pos) is equal to the length of the object
+                # hence the range is "unsatisfiable", and botocore correctly handles it by
+                # raising an exception. We'd rather just return with empty file contents here.
+                if size == 0:
+                    break
+
                 r = obj.get(Range="bytes={}-".format(bytes_read))
 
                 try:


### PR DESCRIPTION
## What does this PR do?

Breaks out of the read loop in s3 cat function to avoid [RFC2616#14.35.1](https://datatracker.ietf.org/doc/html/rfc2616#section-14.35.1).

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->
Fixes #603 
