### PR TITLE
Removing deprecated pyarrow.hdfs.connect call from iorw.py

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     GCSFileSystem = missing_dependency_generator("gcsfs", "gcs")
 try:
-    from pyarrow import HadoopFileSystem
+    from pyarrow.fs import HadoopFileSystem
 except ImportError:
     HadoopFileSystem = missing_dependency_generator("pyarrow", "hdfs")
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -47,7 +47,11 @@ try:
 except ImportError:
     GCSFileSystem = missing_dependency_generator("gcsfs", "gcs")
 try:
-    from pyarrow.fs import HadoopFileSystem
+    try:
+      from pyarrow.fs import HadoopFileSystem
+    except ImportError:
+      # Attempt the older package import pattern in case we're using an old dep version.
+      from pyarrow import HadoopFileSystem
 except ImportError:
     HadoopFileSystem = missing_dependency_generator("pyarrow", "hdfs")
 


### PR DESCRIPTION

## What does this PR do?


_Addressing commonly seen warning in iorw.py file._

```
/usr/local/lib/python3.7/dist-packages/papermill/iorw.py:50: FutureWarning: pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.
  from pyarrow import HadoopFileSystem
```

Fixes #600 