### PR TITLE
Bugfix/pickle errors

### DIFF
--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -23,18 +23,26 @@ class PapermillExecutionError(PapermillException):
     """Raised when an exception is encountered in a notebook."""
 
     def __init__(self, cell_index, exec_count, source, ename, evalue, traceback):
+        args = cell_index, exec_count, source, ename, evalue, traceback
         self.cell_index = cell_index
         self.exec_count = exec_count
         self.source = source
         self.ename = ename
         self.evalue = evalue
         self.traceback = traceback
-        message = "\n" + 75 * "-" + "\n"
-        message += 'Exception encountered at "In [%s]":\n' % str(exec_count)
-        message += strip_color("\n".join(traceback))
-        message += "\n"
 
-        super(PapermillExecutionError, self).__init__(message)
+        super(PapermillExecutionError, self).__init__(*args)
+
+    def __str__(self):
+        # Standard Behavior of an exception is to produce a string representation of its arguments
+        # when called with str(). In order to maintain compatability with previous versions which
+        # passed only the message to the superclass constructor, __str__ method is implemented to
+        # provide the same result as was produced in the past.
+        message = "\n" + 75 * "-" + "\n"
+        message += 'Exception encountered at "In [%s]":\n' % str(self.exec_count)
+        message += strip_color("\n".join(self.traceback))
+        message += "\n"
+        return message
 
 
 class PapermillRateLimitException(PapermillException):

--- a/papermill/tests/test_exceptions.py
+++ b/papermill/tests/test_exceptions.py
@@ -1,1 +1,26 @@
+import os
+import pickle
+import tempfile
+
 import pytest  # noqa
+
+from .. import exceptions
+
+
+@pytest.fixture
+def temp_file():
+    f = tempfile.NamedTemporaryFile()
+    yield f
+    f.close()
+
+
+def test_exceptions_are_unpickleable(temp_file):
+    """Ensure Exceptions can be unpickled"""
+    err = exceptions.PapermillExecutionError(1, 2, "TestSource", "Exception", Exception(), ["Traceback", "Message"])
+    with open(temp_file.name, 'wb') as fd:
+        pickle.dump(err, fd)
+    # Read File
+    temp_file.seek(0)
+    data = temp_file.read()
+    pickled_err = pickle.loads(data)
+    assert str(pickled_err) == str(err)

--- a/papermill/tests/test_exceptions.py
+++ b/papermill/tests/test_exceptions.py
@@ -1,4 +1,3 @@
-import os
 import pickle
 import tempfile
 
@@ -14,12 +13,30 @@ def temp_file():
     f.close()
 
 
-def test_exceptions_are_unpickleable(temp_file):
-    """Ensure Exceptions can be unpickled"""
-    err = exceptions.PapermillExecutionError(1, 2, "TestSource", "Exception", Exception(), ["Traceback", "Message"])
+@pytest.mark.parametrize(
+    "exc,args",
+    [
+        (
+            exceptions.PapermillExecutionError,
+            (1, 2, "TestSource", "Exception", Exception(), ["Traceback", "Message"]),
+        ),
+        (exceptions.PapermillMissingParameterException, ("PapermillMissingParameterException",)),
+        (exceptions.AwsError, ("AwsError",)),
+        (exceptions.FileExistsError, ("FileExistsError",)),
+        (exceptions.PapermillException, ("PapermillException",)),
+        (exceptions.PapermillRateLimitException, ("PapermillRateLimitException",)),
+        (
+            exceptions.PapermillOptionalDependencyException,
+            ("PapermillOptionalDependencyException",),
+        ),
+    ],
+)
+def test_exceptions_are_unpickleable(temp_file, exc, args):
+    """Ensure exceptions can be unpickled"""
+    err = exc(*args)
     with open(temp_file.name, 'wb') as fd:
         pickle.dump(err, fd)
-    # Read File
+    # Read the Pickled File
     temp_file.seek(0)
     data = temp_file.read()
     pickled_err = pickle.loads(data)


### PR DESCRIPTION
## What does this PR do?
Adds the ability to load PapermillExecutionErrors from pickle files. 

Airflow 2.0.0 changed the way it handles error reporting by temporarily pickling the exception. Prior to this commit, papermill exceptions could be pickled by airflow, but then not loaded back, causing cryptic error messages. 

This pull request addresses this issue, by modifying the call to the superclass, and sending up all the arguments used to create the exception. It also implements a `__str__` method, to maintain compatibility with the behavior of calling `str()` on the exception returning the formatted message.


Fixes #628 
