### PR TITLE
Try and get version info when loading notebook

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -458,7 +458,9 @@ def load_notebook_node(notebook_path):
 
     """
     nb = nbformat.reads(papermill_io.read(notebook_path), as_version=4)
-    nb_upgraded = nbformat.v4.upgrade(nb)
+    version = nb.get("nbformat", 3)
+    version_minor = nb.get("nbformat_minor", 0)
+    nb_upgraded = nbformat.v4.upgrade(nb, from_version=version, from_minor=version_minor)
     if nb_upgraded is not None:
         nb = nb_upgraded
 


### PR DESCRIPTION
## What does this PR do?

There seems to be a bug in loading notebooks that tries to get the schema for v3 notebooks when the notebook specifies v4. 

In the output below I put a print statement above this line: https://github.com/jupyter/nbformat/blob/5.0.7/nbformat/validator.py#L103

Before the change

<details>

```
papermill --help-notebook template.ipynb 
/opt/conda/lib/python3.8/site-packages/papermill/iorw.py:49: FutureWarning: pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.
  from pyarrow import HadoopFileSystem
v.nbformat_schema={(None, None): 'nbformat.v4.schema.json', (4, 0): 'nbformat.v4.0.schema.json', (4, 1): 'nbformat.v4.1.schema.json', (4, 2): 'nbformat.v4.2.schema.json', (4, 3): 'nbformat.v4.3.schema.json', (4, 4): 'nbformat.v4.4.schema.json'}
v.nbformat_schema={(3, 0): 'nbformat.v3.schema.json'}
Traceback (most recent call last):
  File "/opt/conda/bin/papermill", line 10, in <module>
    sys.exit(papermill())
  File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/papermill/cli.py", line 247, in papermill
    sys.exit(display_notebook_help(click_ctx, notebook_path, parameters_final))
  File "/opt/conda/lib/python3.8/site-packages/papermill/inspection.py", line 67, in display_notebook_help
    nb = _open_notebook(notebook_path, parameters)
  File "/opt/conda/lib/python3.8/site-packages/papermill/inspection.py", line 19, in _open_notebook
    return load_notebook_node(input_path)
  File "/opt/conda/lib/python3.8/site-packages/papermill/iorw.py", line 397, in load_notebook_node
    nb_upgraded = nbformat.v4.upgrade(nb)
  File "/opt/conda/lib/python3.8/site-packages/nbformat/v4/convert.py", line 39, in upgrade
    _warn_if_invalid(nb, from_version)
  File "/opt/conda/lib/python3.8/site-packages/nbformat/v4/convert.py", line 21, in _warn_if_invalid
    validate(nb, version=version)
  File "/opt/conda/lib/python3.8/site-packages/nbformat/validator.py", line 282, in validate
    for error in iter_validate(
  File "/opt/conda/lib/python3.8/site-packages/nbformat/validator.py", line 305, in iter_validate
    validator = get_validator(version, version_minor, relax_add_props=relax_add_props)
  File "/opt/conda/lib/python3.8/site-packages/nbformat/validator.py", line 70, in get_validator
    schema_json = _get_schema_json(v, version=version, version_minor=version_minor)
  File "/opt/conda/lib/python3.8/site-packages/nbformat/validator.py", line 105, in _get_schema_json
    schema_path = os.path.join(os.path.dirname(v.__file__), v.nbformat_schema[(None, None)])
KeyError: (None, None)
```

</details>

After the change

<details>

```
papermill --help-notebook template.ipynb 
/opt/conda/lib/python3.8/site-packages/papermill/iorw.py:49: FutureWarning: pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.
  from pyarrow import HadoopFileSystem
v.nbformat_schema={(None, None): 'nbformat.v4.schema.json', (4, 0): 'nbformat.v4.0.schema.json', (4, 1): 'nbformat.v4.1.schema.json', (4, 2): 'nbformat.v4.2.schema.json', (4, 3): 'nbformat.v4.3.schema.json', (4, 4): 'nbformat.v4.4.schema.json'}
Usage: papermill [OPTIONS] NOTEBOOK_PATH [OUTPUT_PATH]

Parameters inferred for notebook 'template.ipynb':
  foo: Unknown type (default "bar")
```

</details>

Version info:
```
papermill                 2.3.3              pyhd8ed1ab_0    conda-forge
nbformat                  5.0.7                      py_0    conda-forge
jupyter                   1.0.0            py38h578d9bd_6    conda-forge
```

Notebook `template.ipynb`

<details>

```
{
 "cells": [
  {
   "cell_type": "code",
   "execution_count": null,
   "id": "003900b7-dc43-4b64-bfc3-3baf95b7b4a2",
   "metadata": {
    "tags": [
     "parameters"
    ]
   },
   "outputs": [],
   "source": [
    "foo = \"bar\""
   ]
  }
 ],
 "metadata": {
  "celltoolbar": "Tags",
  "kernelspec": {
   "display_name": "Python 3 (ipykernel)",
   "language": "python",
   "name": "python3"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.8.12"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 5
}
```

</details>