### PR TITLE
fix(iorw.py): misleading output message

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -138,7 +138,7 @@ class PapermillIO(object):
             fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*' + ext) for ext in extensions
         ):
             warnings.warn(
-                "The specified input file ({}) does not end in one of {}".format(path, extensions)
+                "The specified output file ({}) does not end in one of {}".format(path, extensions)
             )
         return self.get_handler(path).write(buf, path)
 


### PR DESCRIPTION
## What does this PR do?

`papermill foobar.ipynb foobar.ipynb.out` gives me the followings:

```
papermill/iorw.py:126: UserWarning: The specified input file (foobar.ipynb.out) does not end in one of ['.ipynb', '.json']
  "The specified input file ({}) does not end in one of {}".format(path, extensions)
```

Which led me think it took the output path as input file.