### PR TITLE
Corrected Azure Blob URI regex matching if the blob include some prefix

### DIFF
--- a/papermill/abs.py
+++ b/papermill/abs.py
@@ -30,7 +30,7 @@ class AzureBlobStore(object):
         see: https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1  # noqa: E501
         abs://myaccount.blob.core.windows.net/sascontainer/sasblob.txt?sastoken
         """
-        match = re.match(r"abs://(.*)\.blob\.core\.windows\.net\/(.*)\/(.*)\?(.*)$", url)
+        match = re.match(r"abs://(.*)\.blob\.core\.windows\.net\/(.*?)\/(.*)\?(.*)$", url)
         if not match:
             raise Exception("Invalid azure blob url '{0}'".format(url))
         else:

--- a/papermill/tests/test_abs.py
+++ b/papermill/tests/test_abs.py
@@ -50,6 +50,15 @@ class ABSTest(unittest.TestCase):
         self.assertEqual(params["blob"], "sasblob.txt")
         self.assertEqual(params["sas_token"], "sastoken")
 
+    def test_split_url_splits_valid_url_with_prefix(self):
+        params = AzureBlobStore._split_url(
+            "abs://myaccount.blob.core.windows.net/sascontainer/A/B/sasblob.txt?sastoken"
+        )
+        self.assertEqual(params["account"], "myaccount")
+        self.assertEqual(params["container"], "sascontainer")
+        self.assertEqual(params["blob"], "A/B/sasblob.txt")
+        self.assertEqual(params["sas_token"], "sastoken")
+
     def test_listdir_calls(self):
         self.assertEqual(
             self.abs.listdir(


### PR DESCRIPTION
## What does this PR do?
Fixes #653