### PR TITLE
fix(iorw.py): update HDFSHandler to adapt PyArrow.fs.HadoopFileSystem API

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -358,7 +358,7 @@ class HDFSHandler(object):
 
     def _get_client(self):
         if self._client is None:
-            self._client = HadoopFileSystem()
+            self._client = HadoopFileSystem(host="default")
         return self._client
 
     def read(self, path):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -51,13 +51,10 @@ except ImportError:
     GCSFileSystem = missing_dependency_generator("gcsfs", "gcs")
 
 try:
-    try:
-        from pyarrow.fs import HadoopFileSystem
-    except ImportError:
-        # Attempt the older package import pattern in case we're using an old dep version.
-        from pyarrow import HadoopFileSystem
+    from pyarrow.fs import HadoopFileSystem, FileSelector
 except ImportError:
     HadoopFileSystem = missing_dependency_generator("pyarrow", "hdfs")
+
 try:
     from github import Github
 except ImportError:
@@ -362,14 +359,14 @@ class HDFSHandler(object):
         return self._client
 
     def read(self, path):
-        with self._get_client().open(path, 'rb') as f:
+        with self._get_client().open_input_stream(path) as f:
             return f.read()
 
     def listdir(self, path):
-        return self._get_client().ls(path)
+        return [f.path for f in self._get_client().get_file_info(FileSelector(path))]
 
     def write(self, buf, path):
-        with self._get_client().open(path, 'wb') as f:
+        with self._get_client().open_output_stream(path) as f:
             return f.write(str.encode(buf))
 
     def pretty_path(self, path):

--- a/papermill/tests/test_hdfs.py
+++ b/papermill/tests/test_hdfs.py
@@ -3,14 +3,15 @@ from unittest.mock import MagicMock, patch
 
 from ..iorw import HDFSHandler
 
-
 class MockHadoopFileSystem(MagicMock):
-    def ls(self, path):
-        return ['test1.ipynb', 'test2.ipynb']
+    def get_file_info(self, path):
+        return [MockFileInfo('test1.ipynb'), MockFileInfo('test2.ipynb')]
 
-    def open(self, path, *args):
+    def open_input_stream(self, path):
         return MockHadoopFile()
 
+    def open_output_stream(self, path):
+        return MockHadoopFile()
 
 class MockHadoopFile(object):
     def __init__(self):
@@ -28,6 +29,10 @@ class MockHadoopFile(object):
     def write(self, new_content):
         self._content = new_content
         return 1
+
+class MockFileInfo(object):
+    def __init__(self, path):
+        self.path = path
 
 
 @patch('papermill.iorw.HadoopFileSystem', side_effect=MockHadoopFileSystem())

--- a/papermill/tests/test_hdfs.py
+++ b/papermill/tests/test_hdfs.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from ..iorw import HDFSHandler
 
+
 class MockHadoopFileSystem(MagicMock):
     def get_file_info(self, path):
         return [MockFileInfo('test1.ipynb'), MockFileInfo('test2.ipynb')]

--- a/requirements/hdfs.txt
+++ b/requirements/hdfs.txt
@@ -1,1 +1,1 @@
-pyarrow
+pyarrow >= 2.0


### PR DESCRIPTION
## What does this PR do?

Fixes #657 

I fix HDFSHandler to match PyArrow.fs.HadoopFileSystem API.
 
As stated the reasons in #657, I removed `import PyArrow.HadoopFileSystm` and updated `requirements/hdfs.txt`.