### PR TITLE
use unittest.mock instead of mock

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,5 @@
 Sphinx==3.5.4
 furo==2021.4.11b34
 myst-parser==0.13.7
-mock==4.0.3
 moto==2.0.5
 sphinx-copybutton==0.3.1

--- a/papermill/tests/test_autosave.py
+++ b/papermill/tests/test_autosave.py
@@ -4,7 +4,7 @@ import tempfile
 import time
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 from . import get_notebook_path
 

--- a/papermill/tests/test_autosave.py
+++ b/papermill/tests/test_autosave.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 import time
 import unittest
-
 from unittest.mock import patch
 
 from . import get_notebook_path

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -17,7 +17,7 @@ import unittest
 import pytest
 from click.testing import CliRunner
 
-from mock import patch
+from unittest.mock import patch
 
 from . import get_notebook_path, kernel_name
 from .. import cli

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -13,11 +13,10 @@ import nbclient
 import nbformat
 from jupyter_client import kernelspec
 import unittest
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
-
-from unittest.mock import patch
 
 from . import get_notebook_path, kernel_name
 from .. import cli

--- a/papermill/tests/test_clientwrap.py
+++ b/papermill/tests/test_clientwrap.py
@@ -1,7 +1,7 @@
 import nbformat
 import unittest
 
-from mock import call, patch
+from unittest.mock import call, patch
 
 from . import get_notebook_path
 

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -3,7 +3,7 @@ import dateutil
 import unittest
 
 from abc import ABCMeta
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 from nbformat.notebooknode import NotebookNode
 
 from . import get_notebook_path

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -12,7 +12,7 @@ from nbformat import validate
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 from .. import engines
 from ..log import logger

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -3,16 +3,12 @@ import io
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from functools import partial
 from pathlib import Path
 
 from nbformat import validate
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from unittest.mock import patch
 
 from .. import engines
 from ..log import logger

--- a/papermill/tests/test_gcs.py
+++ b/papermill/tests/test_gcs.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest.mock import patch
 
 from ..exceptions import PapermillRateLimitException

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,6 @@ google_compute_engine # Need this because boto has issues with dynamic package l
 ipython>=5.0
 ipywidgets
 notebook
-mock
 moto
 pytest>=4.1
 pytest-cov>=2.6.1


### PR DESCRIPTION
## What does this PR do?

Changed to use `unittest.mock` instead of `mock`.
- Supported versions of Python have `unittest` as a standard library,
- Unnecessary dependencies can be removed.

Fixes #659
