### PR TITLE
Option for not writing an output ipynb file

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -36,8 +36,8 @@ def execute_notebook(
     ----------
     input_path : str or Path
         Path to input notebook
-    output_path : str or Path
-        Path to save executed notebook
+    output_path : str or Path or None
+        Path to save executed notebook. If None, no file will be saved
     parameters : dict, optional
         Arbitrary keyword arguments to pass to the notebook parameters
     engine_name : str, optional

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -116,6 +116,8 @@ class PapermillIO(object):
         return notebook_metadata
 
     def write(self, buf, path, extensions=['.ipynb', '.json']):
+        if path is None:
+            return
         if path == '-':
             try:
                 return sys.stdout.buffer.write(buf.encode('utf-8'))
@@ -158,6 +160,9 @@ class PapermillIO(object):
             self.register(entrypoint.name, entrypoint.load())
 
     def get_handler(self, path):
+        if path is None:
+            return NoIOHandler()
+
         local_handler = None
         for scheme, handler in self._handlers:
             if scheme == 'local':
@@ -404,6 +409,22 @@ class GithubHandler(object):
 
     def pretty_path(self, path):
         return path
+
+
+class NoIOHandler(object):
+    '''Handler for output_path of None - intended to not write anything'''
+
+    def read(self, path):
+        raise PapermillException('read is not supported by NoIOHandler')
+
+    def listdir(self, path):
+        raise PapermillException('listdir is not supported by NoIOHandler')
+
+    def write(self, buf, path):
+        return
+
+    def pretty_path(self, path):
+        return 'Notebook will not be saved'
 
 
 # Hack to make YAML loader not auto-convert datetimes

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -38,11 +38,14 @@ def parameterize_path(path, parameters):
 
     Parameters
     ----------
-    path : string
+    path : string or None
        Path with optional parameters, as a python format string
-    parameters : dict
+    parameters : dict or None
        Arbitrary keyword arguments to fill in the path
     """
+    if path is None:
+        return
+
     if parameters is None:
         parameters = {}
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -230,6 +230,13 @@ class TestReportMode(unittest.TestCase):
                 self.assertEqual(cell.metadata.get('jupyter', {}).get('source_hidden'), True)
 
 
+class TestOutputPathNone(unittest.TestCase):
+    def test_output_path_of_none(self):
+        """Output path of None should return notebook node obj but not write an ipynb"""
+        nb = execute_notebook(get_notebook_path('simple_execute.ipynb'), None, {'msg': 'Hello'})
+        self.assertEqual(nb.metadata.papermill.parameters, {'msg': 'Hello'})
+
+
 class TestCWD(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -15,6 +15,7 @@ from .. import iorw
 from ..iorw import (
     HttpHandler,
     LocalHandler,
+    NoIOHandler,
     ADLHandler,
     PapermillIO,
     read_yaml_file,
@@ -90,6 +91,9 @@ class TestPapermillIO(unittest.TestCase):
         self.papermill_io.register("local", self.fake2)
         self.assertEqual(self.papermill_io.get_handler("dne"), self.fake2)
 
+    def test_get_no_io_handler(self):
+        self.assertIsInstance(self.papermill_io.get_handler(None), NoIOHandler)
+
     def test_entrypoint_register(self):
 
         fake_entrypoint = Mock(load=Mock())
@@ -162,6 +166,9 @@ class TestPapermillIO(unittest.TestCase):
     def test_write_with_no_file_extension(self):
         with pytest.warns(UserWarning):
             self.papermill_io.write("buffer", "fake/path")
+
+    def test_write_with_path_of_none(self):
+        self.assertIsNone(self.papermill_io.write('buffer', None))
 
     def test_write_with_invalid_file_extension(self):
         with pytest.warns(UserWarning):
@@ -244,6 +251,23 @@ class TestLocalHandler(unittest.TestCase):
         # be a file and an IOError will be raised
         with self.assertRaises(IOError):
             LocalHandler().read("a random string")
+
+
+class TestNoIOHandler(unittest.TestCase):
+    def test_raises_on_read(self):
+        with self.assertRaises(PapermillException):
+            NoIOHandler().read(None)
+
+    def test_raises_on_listdir(self):
+        with self.assertRaises(PapermillException):
+            NoIOHandler().listdir(None)
+
+    def test_write_returns_none(self):
+        self.assertIsNone(NoIOHandler().write('buf', None))
+
+    def test_pretty_path(self):
+        expect = 'Notebook will not be saved'
+        self.assertEqual(NoIOHandler().pretty_path(None), expect)
 
 
 class TestADLHandler(unittest.TestCase):

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -166,3 +166,7 @@ class TestPathParameterizing(unittest.TestCase):
         with self.assertRaises(PapermillMissingParameterException) as context:
             parameterize_path("{foo}", None)
         self.assertEqual(str(context.exception), "Missing parameter 'foo'")
+
+    def test_path_of_none_returns_none(self):
+        self.assertIsNone(parameterize_path(path=None, parameters={'foo': 'bar'}))
+        self.assertIsNone(parameterize_path(path=None, parameters=None))


### PR DESCRIPTION
## What does this PR do?

In the current setup of papermill, an `output_path` is required to write an output ipynb file even if you only want to use the returned `NotebookNode` object. For example, in my case, I end up using `tempfile` a good amount to get around this.

This motivation came up in PR https://github.com/nteract/papermill/pull/107, as well

#### Approach

Let user pass `output_path = None` to indicate they don't want to write an output ipynb.

A new IO handler was added, `NoIOHandler` to deal with this option.

#### Alternative approach

I tried to match the api interface of PR https://github.com/nteract/papermill/pull/107, but I could also see having a specific string that indicates no output writing (similar to `"-"` indicating stdin/stdout).

The advantage being that the IO handler can be registered in the IO factory as designed, and not implemented outside of it as I had to do with `path=None`, since [`get_handler`](https://github.com/nteract/papermill/blob/main/papermill/iorw.py#L160) uses `path.startswith`.

If that sounds like a better approach, I'm open to string suggestions - haven't thought of a good one yet :)