### PR TITLE
Adds input of NotebookNode object directly

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -34,8 +34,8 @@ def execute_notebook(
 
     Parameters
     ----------
-    input_path : str or Path
-        Path to input notebook
+    input_path : str or Path or nbformat.NotebookNode
+        Path to input notebook or NotebookNode object of notebook
     output_path : str or Path or None
         Path to save executed notebook. If None, no file will be saved
     parameters : dict, optional

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -123,23 +123,43 @@ class PapermillIO(object):
         for entrypoint in entrypoints.get_group_all("papermill.io"):
             self.register(entrypoint.name, entrypoint.load())
 
-    def get_handler(self, path, extensions=['.ipynb', '.json']):
+    def get_handler(self, path, extensions=None):
+        """Get I/O Handler based on a notebook path
+
+        Parameters
+        ----------
+        path : str or nbformat.NotebookNode or None
+        extensions : list of str, optional
+            Required file extension options for the path (if path is a string), which
+            will log a warning if there is no match. Defaults to None, which does not
+            check for any extensions
+
+        Raises
+        ------
+        PapermillException: If a valid I/O handler could not be found for the input path
+
+        Returns
+        -------
+        I/O Handler
+        """
         if path is None:
             return NoIOHandler()
 
         if isinstance(path, nbformat.NotebookNode):
             return NotebookNodeHandler()
 
-        if not fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*.*'):
-            warnings.warn(
-                "the file is not specified with any extension : " + os.path.basename(path)
-            )
-        elif not any(
-            fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*' + ext) for ext in extensions
-        ):
-            warnings.warn(
-                "The specified file ({}) does not end in one of {}".format(path, extensions)
-            )
+        if extensions:
+            if not fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*.*'):
+                warnings.warn(
+                    "the file is not specified with any extension : " + os.path.basename(path)
+                )
+            elif not any(
+                fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*' + ext)
+                for ext in extensions
+            ):
+                warnings.warn(
+                    "The specified file ({}) does not end in one of {}".format(path, extensions)
+                )
 
         local_handler = None
         for scheme, handler in self._handlers:

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -441,7 +441,7 @@ class NotebookNodeHandler(object):
         raise PapermillException('write is not supported by NotebookNode Handler')
 
     def pretty_path(self, path):
-        return "NotebookNode object"
+        return 'NotebookNode object'
 
 
 class NoIOHandler(object):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -414,7 +414,7 @@ class StreamHandler(object):
         return sys.stdin.read()
 
     def listdir(self, path):
-        raise PapermillException('listdir is not supported by Stdin/Stdout')
+        raise PapermillException('listdir is not supported by Stream Handler')
 
     def write(self, buf, path):
         try:
@@ -440,6 +440,7 @@ class NotebookNodeHandler(object):
 
     def pretty_path(self, path):
         return "NotebookNode object"
+
 
 class NoIOHandler(object):
     '''Handler for output_path of None - intended to not write anything'''

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -124,7 +124,7 @@ class PapermillIO(object):
             self.register(entrypoint.name, entrypoint.load())
 
     def get_handler(self, path, extensions=None):
-        """Get I/O Handler based on a notebook path
+        '''Get I/O Handler based on a notebook path
 
         Parameters
         ----------
@@ -141,7 +141,7 @@ class PapermillIO(object):
         Returns
         -------
         I/O Handler
-        """
+        '''
         if path is None:
             return NoIOHandler()
 
@@ -410,6 +410,7 @@ class GithubHandler(object):
 
 
 class StreamHandler(object):
+    '''Handler for Stdin/Stdout streams'''
     def read(self, path):
         return sys.stdin.read()
 
@@ -429,6 +430,7 @@ class StreamHandler(object):
 
 
 class NotebookNodeHandler(object):
+    '''Handler for input_path of nbformat.NotebookNode object'''
     def read(self, path):
         return nbformat.writes(path)
 

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -43,6 +43,8 @@ def parameterize_path(path, parameters):
     parameters : dict
        Arbitrary keyword arguments to fill in the path
     """
+    if isinstance(path, nbformat.NotebookNode):
+        return path
     if parameters is None:
         parameters = {}
 

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -38,15 +38,13 @@ def parameterize_path(path, parameters):
 
     Parameters
     ----------
-    path : string or None
-       Path with optional parameters, as a python format string
+    path : string or nbformat.NotebookNode or None
+       Path with optional parameters, as a python format string. If path is a NotebookNode
+       or None, the path is returned without modification
     parameters : dict or None
        Arbitrary keyword arguments to fill in the path
     """
-    if path is None:
-        return
-
-    if isinstance(path, nbformat.NotebookNode):
+    if path is None or isinstance(path, nbformat.NotebookNode):
         return path
 
     if parameters is None:

--- a/papermill/tests/notebooks/test_notebooknode_io.ipynb
+++ b/papermill/tests/notebooks/test_notebooknode_io.ipynb
@@ -1,0 +1,20 @@
+{
+"cells": [
+{
+"cell_type": "code",
+"execution_count": null,
+"metadata": {},
+"outputs": [],
+"source": ["print('Hello World')"]
+}
+],
+"metadata": {
+"kernelspec": {
+"display_name": "Python 3",
+"language": "python",
+"name": "python3"
+}
+},
+"nbformat": 4,
+"nbformat_minor": 2
+}

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -399,5 +399,6 @@ class TestNotebookNodeInput(unittest.TestCase):
 
     def test_notebook_node_input(self):
         input_nb = nbformat.read(get_notebook_path('simple_execute.ipynb'), as_version=4)
-        test_nb = execute_notebook(input_nb, self.result_path, {'msg': 'Hello'})
+        execute_notebook(input_nb, self.result_path, {'msg': 'Hello'})
+        test_nb = nbformat.read(self.result_path, as_version=4)
         self.assertEqual(test_nb.metadata.papermill.parameters, {'msg': 'Hello'})

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from functools import partial
 from pathlib import Path
 
+import nbformat
 from nbformat import validate
 
 from .. import engines
@@ -379,3 +380,17 @@ class TestMinimalNotebook(unittest.TestCase):
         execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
         nb = load_notebook_node(result_path)
         validate(nb)
+
+
+class TestNotebookNodeInput(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.result_path = os.path.join(self.test_dir.name, 'output.ipynb')
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_notebook_node_input(self):
+        input_nb = nbformat.read(get_notebook_path('simple_execute.ipynb'), as_version=4)
+        test_nb = execute_notebook(input_nb, self.result_path, {'msg': 'Hello'})
+        self.assertEqual(test_nb.metadata.papermill.parameters, {'msg': 'Hello'})

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -151,7 +151,7 @@ class TestPapermillIO(unittest.TestCase):
     def test_read_stdin(self):
         file_content = u'Τὴ γλῶσσα μοῦ ἔδωσαν ἑλληνικὴ'
         with patch('sys.stdin', io.StringIO(file_content)):
-            self.assertEqual(self.papermill_io.read("-"), file_content)
+            self.assertEqual(self.old_papermill_io.read("-"), file_content)
 
     def test_listdir(self):
         self.assertEqual(self.papermill_io.listdir("fake/path"), ["fake", "contents"])
@@ -171,7 +171,7 @@ class TestPapermillIO(unittest.TestCase):
         file_content = u'Τὴ γλῶσσα μοῦ ἔδωσαν ἑλληνικὴ'
         out = io.BytesIO()
         with patch('sys.stdout', out):
-            self.papermill_io.write(file_content, "-")
+            self.old_papermill_io.write(file_content, "-")
             self.assertEqual(out.getvalue(), file_content.encode('utf-8'))
 
     def test_pretty_path(self):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -97,6 +97,10 @@ class TestPapermillIO(unittest.TestCase):
     def test_get_no_io_handler(self):
         self.assertIsInstance(self.papermill_io.get_handler(None), NoIOHandler)
 
+    def test_get_notebook_node_handler(self):
+        test_nb = nbformat.read(get_notebook_path('test_notebooknode_io.ipynb'), as_version=4)
+        self.assertIsInstance(self.papermill_io.get_handler(test_nb), NotebookNodeHandler)
+
     def test_entrypoint_register(self):
 
         fake_entrypoint = Mock(load=Mock())

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -170,3 +170,8 @@ class TestPathParameterizing(unittest.TestCase):
     def test_path_of_none_returns_none(self):
         self.assertIsNone(parameterize_path(path=None, parameters={'foo': 'bar'}))
         self.assertIsNone(parameterize_path(path=None, parameters=None))
+
+    def test_path_of_notebook_node_returns_input(self):
+        test_nb = load_notebook_node(get_notebook_path("simple_execute.ipynb"))
+        result_nb = parameterize_path(test_nb, parameters=None)
+        self.assertIs(result_nb, test_nb)


### PR DESCRIPTION
## What does this PR do?

User can pass an in-memory `nbformat.NotebookNode` object to `pm.execute_notebook` instead of requiring a path.

Related to issue https://github.com/nteract/papermill/issues/444

This adds a `NotebookNodeHandler` to read the input object.

A bit of refactoring was also needed to move code that expected a string:

- Stdin/Stdout was pulled out into its own handler
- The check and warning for `.ipynb` and `.json` file extensions by `PapermillIO` read/write was moved into `get_handler` (this also made the code more DRY)

Happy to take feedback, thanks!