### PR TITLE
1 of 2 failing tests on Windows (test_exceptions.py)

### DIFF
--- a/papermill/tests/test_exceptions.py
+++ b/papermill/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import tempfile
 
@@ -8,9 +9,11 @@ from .. import exceptions
 
 @pytest.fixture
 def temp_file():
-    f = tempfile.NamedTemporaryFile()
-    yield f
-    f.close()
+    """NamedTemporaryFile must be set in wb mode, closed without delete, opened with open(file, "rb"),
+    then manually deleted. Otherwise, file fails to be read due to permission error on Windows."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        yield f
+        os.unlink(f.name)
 
 
 @pytest.mark.parametrize(
@@ -34,10 +37,12 @@ def temp_file():
 def test_exceptions_are_unpickleable(temp_file, exc, args):
     """Ensure exceptions can be unpickled"""
     err = exc(*args)
-    with open(temp_file.name, 'wb') as fd:
-        pickle.dump(err, fd)
+    pickle.dump(err, temp_file)
+    temp_file.close()  # close to re-open for reading
+
     # Read the Pickled File
-    temp_file.seek(0)
-    data = temp_file.read()
-    pickled_err = pickle.loads(data)
-    assert str(pickled_err) == str(err)
+    with open(temp_file.name, "rb") as read_file:
+        read_file.seek(0)
+        data = read_file.read()
+        pickled_err = pickle.loads(data)
+        assert str(pickled_err) == str(err)


### PR DESCRIPTION
This pull request fixes multiple failing tests within test_exceptions.py when papermill is run on the windows platform. Specifically, the previous behavior of the code created a temporary file with the incorrect permissions assigned to it resulting in a PermissionDenied error.