### PR TITLE
2 failing test fixes for Windows platform

### DIFF
--- a/papermill/tests/test_exceptions.py
+++ b/papermill/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import tempfile
 
@@ -8,9 +9,11 @@ from .. import exceptions
 
 @pytest.fixture
 def temp_file():
-    f = tempfile.NamedTemporaryFile()
-    yield f
-    f.close()
+    """NamedTemporaryFile must be set in wb mode, closed without delete, opened with open(file, "rb"),
+    then manually deleted. Otherwise, file fails to be read due to permission error on Windows."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        yield f
+        os.unlink(f.name)
 
 
 @pytest.mark.parametrize(
@@ -34,10 +37,12 @@ def temp_file():
 def test_exceptions_are_unpickleable(temp_file, exc, args):
     """Ensure exceptions can be unpickled"""
     err = exc(*args)
-    with open(temp_file.name, 'wb') as fd:
-        pickle.dump(err, fd)
+    pickle.dump(err, temp_file)
+    temp_file.close()  # close to re-open for reading
+
     # Read the Pickled File
-    temp_file.seek(0)
-    data = temp_file.read()
-    pickled_err = pickle.loads(data)
-    assert str(pickled_err) == str(err)
+    with open(temp_file.name, "rb") as read_file:
+        read_file.seek(0)
+        data = read_file.read()
+        pickled_err = pickle.loads(data)
+        assert str(pickled_err) == str(err)

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -1,9 +1,9 @@
-import os
 import pytest
 import warnings
 
 from unittest.mock import Mock, call
 from tempfile import TemporaryDirectory
+from pathlib import Path
 
 from nbformat.v4 import new_notebook, new_code_cell
 
@@ -52,10 +52,10 @@ def test_retry():
 
 
 def test_chdir():
-    old_cwd = os.getcwd()
+    old_cwd = Path.cwd()
     with TemporaryDirectory() as temp_dir:
         with chdir(temp_dir):
-            assert os.getcwd() != old_cwd
-            assert os.getcwd() == os.path.realpath(temp_dir)
+            assert Path.cwd() != old_cwd
+            assert Path.cwd() == Path(temp_dir)
 
-    assert os.getcwd() == old_cwd
+    assert Path.cwd() == old_cwd


### PR DESCRIPTION
This pull request fixes multiple failing tests within test_exceptions.py and test_utils.py when papermill is run on the windows platform. 

test_exceptions.py : test_exceptions_are_unpickleable
The previous behavior of the code created a temporary file with the incorrect permissions assigned to it resulting in a PermissionDenied error.

test_utils.py : test_chdir
The previous behavior of the code used os.path to compare against strings, which had the issue of sometimes comparing minified path strings (such as 'C:\\Users\\USER~1\\Path\\To\\My\\Basement') to non-minified path strings. New code uses more commonly used pathlib library to get and compare Paths.