### PR TITLE
Remove deepcopy steps during parameterize_notebook.

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import copy
 import nbformat
 from pathlib import Path
 
@@ -148,9 +147,6 @@ def prepare_notebook_metadata(nb, input_path, output_path, report_mode=False):
     report_mode : bool, optional
        Flag to set report mode
     """
-    # Copy the nb object to avoid polluting the input
-    nb = copy.deepcopy(nb)
-
     # Hide input if report-mode is set to True.
     if report_mode:
         for cell in nb.cells:
@@ -185,7 +181,6 @@ ERROR_ANCHOR_MSG = (
 
 
 def remove_error_markers(nb):
-    nb = copy.deepcopy(nb)
     nb.cells = [cell for cell in nb.cells if ERROR_MARKER_TAG not in cell.metadata.get("tags", [])]
     return nb
 

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -1,4 +1,3 @@
-import copy
 import nbformat
 
 from .engines import papermill_engines
@@ -81,9 +80,6 @@ def parameterize_notebook(
     # Load from a file if 'parameters' is a string.
     if isinstance(parameters, str):
         parameters = read_yaml_file(parameters)
-
-    # Copy the nb object to avoid polluting the input
-    nb = copy.deepcopy(nb)
 
     # Fetch out the name and language from the notebook document by dropping-down into the engine's implementation
     kernel_name = papermill_engines.nb_kernel_name(engine_name, nb, kernel_name)


### PR DESCRIPTION
This PR removes the `nb = copy.deepcopy(nb)` steps inside parameterize.py and execute.py. This does not fix any tracked issue I know of. What this PR solves are some issues and annoyances surrounding the deepcopy (and pickle) standard libraries.

```python
# Copy the nb object to avoid polluting the input
nb = copy.deepcopy(nb)
```

Currently, notebooks that contain cells or parameters with objects without a \_\_dict\_\_ require some heavy object/class patching of their magic methods. Also, anything that is unable to be serialized with pickle will run into issues here as well. Removing all of the `copy.deepcopy(nb)` calls fixes this issue.

The removal of these can be done safely because the deepcopy currently has no useful behavior; just looking at the code surrounding these calls makes it somewhat apparent. All tests are currently passing on my machine with the removal of these calls to deepcopy, so there would have to be some undocumented use-cases with no matching tests if there are any issues here.