### PR TITLE
Implement bash translator

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -601,3 +601,49 @@ def test_translator_must_implement_comment():
 
     with pytest.raises(NotImplementedError):
         MyNewTranslator.comment("foo")
+
+
+# Bash/sh section
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("foo", "foo"),
+        ("foo space", "'foo space'"),
+        ("foo's apostrophe", "'foo'\"'\"'s apostrophe'"),
+        ("shell ( is ) <dumb>", "'shell ( is ) <dumb>'"),
+        (12345, '12345'),
+        (-54321, '-54321'),
+        (1.2345, '1.2345'),
+        (-5432.1, '-5432.1'),
+        (True, 'true'),
+        (False, 'false'),
+        (None, ''),
+    ],
+)
+def test_translate_type_sh(test_input, expected):
+    assert translators.BashTranslator.translate(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected", [("", '#'), ("foo", '# foo'), ("['best effort']", "# ['best effort']")]
+)
+def test_translate_comment_sh(test_input, expected):
+    assert translators.BashTranslator.comment(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "parameters,expected",
+    [
+        ({"foo": "bar"}, '# Parameters\nfoo=bar\n'),
+        ({"foo": "shell ( is ) <dumb>"}, "# Parameters\nfoo='shell ( is ) <dumb>'\n"),
+        ({"foo": True}, '# Parameters\nfoo=true\n'),
+        ({"foo": 5}, '# Parameters\nfoo=5\n'),
+        ({"foo": 1.1}, '# Parameters\nfoo=1.1\n'),
+        (
+            OrderedDict([['foo', 'bar'], ['baz', '$dumb(shell)']]),
+            "# Parameters\nfoo=bar\nbaz='$dumb(shell)'\n",
+        ),
+    ],
+)
+def test_translate_codify_sh(parameters, expected):
+    assert translators.BashTranslator.codify(parameters) == expected

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import re
+import shlex
 import sys
 
 from .exceptions import PapermillException
@@ -541,6 +542,33 @@ class PowershellTranslator(Translator):
         return '${} = {}'.format(name, str_val)
 
 
+class BashTranslator(Translator):
+    @classmethod
+    def translate_none(cls, val):
+        return ''
+
+    @classmethod
+    def translate_bool(cls, val):
+        return 'true' if val else 'false'
+
+    @classmethod
+    def translate_escaped_str(cls, str_val):
+        return shlex.quote(str(str_val))
+
+    @classmethod
+    def translate_list(cls, val):
+        escaped = ' '.join([cls.translate(v) for v in val])
+        return '({})'.format(escaped)
+
+    @classmethod
+    def comment(cls, cmt_str):
+        return '# {}'.format(cmt_str).strip()
+
+    @classmethod
+    def assign(cls, name, str_val):
+        return '{}={}'.format(name, str_val)
+
+
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
 papermill_translators.register("python", PythonTranslator)
@@ -554,6 +582,7 @@ papermill_translators.register(".net-powershell", PowershellTranslator)
 papermill_translators.register("pysparkkernel", PythonTranslator)
 papermill_translators.register("sparkkernel", ScalaTranslator)
 papermill_translators.register("sparkrkernel", RTranslator)
+papermill_translators.register("bash", BashTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters, comment='Parameters'):


### PR DESCRIPTION
## Support translation of parameters to bash/*NIX shell

Thanks for papermill! I have used it for python notebooks, but a lot of my work is best done in shell, for which I use jupyter notebooks with the [bash_kernel](https://github.com/takluyver/bash_kernel/) (via *.sh scripts and jupytext). 

Alas papermill doesn't seem to support bash/shell script, due to a hitherto unimplemented bash translator. This PR implements a `BashTranslator`, and therefore enables bash kernel notebooks to be parametrised.  This code supports `str`, `list`, `bool`[^1], `None`, `int`, and `float` parameter values. Dict could in theory be supported via [associative arrays](https://linuxhint.com/associative_arrays_bash_examples/) but for now they are not implemented[^2].

For a functioning example, please see the attached notebook.

Best,
K

[^1]: Bash doesn't really have a bool type, but `true` and `false` are at least common and sensible string constants for truthy-ness and falsy-ness. See for example [this SO answer](https://stackoverflow.com/a/21210966).
[^2]: Associative arrays require quite recent bash versions, and I've never seen them used outside tutorials. Supporting them would also likely require a more involved code path as one must pre-declare an associative array in bash, and then declare one entry per line (see link above).
