### PR TITLE
Allow custom implementations of `nb_kernel_name`  and `nb_language` in papermill engines

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -49,7 +49,7 @@ class PapermillEngines(object):
         return self.get_engine(engine_name).execute_notebook(nb, kernel_name, **kwargs)
 
     def nb_kernel_name(self, engine_name, nb, name=None):
-        """Fetch the kernel name from the document by dropping-down into the provided engine."""
+        """Fetch kernel name from the document by dropping-down into the provided engine."""
         return self.get_engine(engine_name).nb_kernel_name(nb, name)
 
     def nb_language(self, engine_name, nb, language=None):

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -54,7 +54,7 @@ class PapermillEngines(object):
         """
         engine = self.get_engine(engine_name)
         if hasattr(engine, "nb_kernel_name"):
-            return self.get_engine(engine_name).nb_kernel_name(nb, name)
+            return engine.nb_kernel_name(nb, name)
         else:
             return nb_kernel_name(nb, name)
 
@@ -64,7 +64,7 @@ class PapermillEngines(object):
         """
         engine = self.get_engine(engine_name)
         if hasattr(engine, "nb_language"):
-            return self.get_engine(engine_name).nb_language(nb, language)
+            return engine.nb_language(nb, language)
         else:
             return nb_language(nb, language)
 

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -49,24 +49,12 @@ class PapermillEngines(object):
         return self.get_engine(engine_name).execute_notebook(nb, kernel_name, **kwargs)
 
     def nb_kernel_name(self, engine_name, nb, name=None):
-        """Fetch the kernel name from the document by dropping-down into the provided engine.
-        If the engine does not implement `nb_kernel_name`, then use the default implementation.
-        """
-        engine = self.get_engine(engine_name)
-        if hasattr(engine, "nb_kernel_name"):
-            return engine.nb_kernel_name(nb, name)
-        else:
-            return nb_kernel_name(nb, name)
+        """Fetch the kernel name from the document by dropping-down into the provided engine."""
+        return self.get_engine(engine_name).nb_kernel_name(nb, name)
 
     def nb_language(self, engine_name, nb, language=None):
-        """Fetch language from the document by dropping-down into the provided engine.
-        If the engine does not implement `nb_language`, then use the default implementation.
-        """
-        engine = self.get_engine(engine_name)
-        if hasattr(engine, "nb_language"):
-            return engine.nb_language(nb, language)
-        else:
-            return nb_language(nb, language)
+        """Fetch language from the document by dropping-down into the provided engine."""
+        return self.get_engine(engine_name).nb_language(nb, language)
 
 
 def catch_nb_assignment(func):

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -92,7 +92,12 @@ def execute_notebook(
         # Parameterize the Notebook.
         if parameters:
             nb = parameterize_notebook(
-                nb, parameters, report_mode, kernel_name=kernel_name, language=language, engine_name=engine_name
+                nb,
+                parameters,
+                report_mode,
+                kernel_name=kernel_name,
+                language=language,
+                engine_name=engine_name,
             )
 
         nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode)
@@ -101,7 +106,9 @@ def execute_notebook(
 
         if not prepare_only:
             # Dropdown to the engine to fetch the kernel name from the notebook document
-            kernel_name = papermill_engines.nb_kernel_name(engine_name=engine_name, nb=nb, name=kernel_name)
+            kernel_name = papermill_engines.nb_kernel_name(
+                engine_name=engine_name, nb=nb, name=kernel_name
+            )
             # Execute the Notebook in `cwd` if it is set
             with chdir(cwd):
                 nb = papermill_engines.execute_notebook_with_engine(

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -92,7 +92,7 @@ def execute_notebook(
         # Parameterize the Notebook.
         if parameters:
             nb = parameterize_notebook(
-                nb, parameters, report_mode, kernel_name=kernel_name, language=language
+                nb, parameters, report_mode, kernel_name=kernel_name, language=language, engine_name=engine_name
             )
 
         nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode)

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -8,7 +8,7 @@ from .log import logger
 from .exceptions import PapermillExecutionError
 from .iorw import get_pretty_path, local_file_io_cwd, load_notebook_node, write_ipynb
 from .engines import papermill_engines
-from .utils import chdir, nb_kernel_name
+from .utils import chdir
 from .parameterize import add_builtin_parameters, parameterize_notebook, parameterize_path
 
 
@@ -100,9 +100,6 @@ def execute_notebook(
         nb = remove_error_markers(nb)
 
         if not prepare_only:
-            # Fetch out the name from the notebook document
-            kernel_name = nb_kernel_name(nb, kernel_name)
-            # Execute the Notebook in `cwd` if it is set
             with chdir(cwd):
                 nb = papermill_engines.execute_notebook_with_engine(
                     engine_name,

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -100,6 +100,8 @@ def execute_notebook(
         nb = remove_error_markers(nb)
 
         if not prepare_only:
+            # Dropdown to the engine to fetch the kernel name from the notebook document
+            kernel_name = papermill_engines.nb_kernel_name(engine_name=engine_name, nb=nb, name=kernel_name)
             # Execute the Notebook in `cwd` if it is set
             with chdir(cwd):
                 nb = papermill_engines.execute_notebook_with_engine(

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -100,6 +100,7 @@ def execute_notebook(
         nb = remove_error_markers(nb)
 
         if not prepare_only:
+            # Execute the Notebook in `cwd` if it is set
             with chdir(cwd):
                 nb = papermill_engines.execute_notebook_with_engine(
                     engine_name,

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -1,11 +1,12 @@
 import copy
 import nbformat
 
+from .engines import papermill_engines
 from .log import logger
 from .exceptions import PapermillMissingParameterException
 from .iorw import read_yaml_file
 from .translators import translate_parameters
-from .utils import find_first_tagged_cell_index, nb_kernel_name, nb_language
+from .utils import find_first_tagged_cell_index
 
 from uuid import uuid4
 from datetime import datetime
@@ -56,7 +57,7 @@ def parameterize_path(path, parameters):
 
 
 def parameterize_notebook(
-    nb, parameters, report_mode=False, comment='Parameters', kernel_name=None, language=None
+    nb, parameters, report_mode=False, comment='Parameters', kernel_name=None, language=None, engine_name=None
 ):
     """Assigned parameters into the appropriate place in the input notebook
 
@@ -78,9 +79,9 @@ def parameterize_notebook(
     # Copy the nb object to avoid polluting the input
     nb = copy.deepcopy(nb)
 
-    # Fetch out the name and language from the notebook document
-    kernel_name = nb_kernel_name(nb, kernel_name)
-    language = nb_language(nb, language)
+    # Fetch out the name and language from the notebook document by dropping-down into the engine's implementation
+    kernel_name = papermill_engines.nb_kernel_name(engine_name, nb, kernel_name)
+    language = papermill_engines.nb_language(engine_name, nb, language)
 
     # Generate parameter content based on the kernel_name
     param_content = translate_parameters(kernel_name, language, parameters, comment)

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -57,7 +57,13 @@ def parameterize_path(path, parameters):
 
 
 def parameterize_notebook(
-    nb, parameters, report_mode=False, comment='Parameters', kernel_name=None, language=None, engine_name=None
+    nb,
+    parameters,
+    report_mode=False,
+    comment='Parameters',
+    kernel_name=None,
+    language=None,
+    engine_name=None,
 ):
     """Assigned parameters into the appropriate place in the input notebook
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from nbformat import validate
 
-from .. import engines, translators, parameterize
+from .. import engines, translators
 from ..log import logger
 from ..iorw import load_notebook_node
 from ..utils import chdir
@@ -423,7 +423,7 @@ class TestExecuteWithCustomEngine(unittest.TestCase):
         translators.papermill_translators = self._orig_translators
 
     @patch.object(CustomEngine, "execute_managed_notebook", wraps=CustomEngine.execute_managed_notebook)
-    @patch(parameterize.__name__ + ".translate_parameters", wraps=translators.translate_parameters)
+    @patch("papermill.parameterize.translate_parameters", wraps=translators.translate_parameters)
     def test_custom_kernel_name_and_language(self, translate_parameters, execute_managed_notebook):
         """Tests execute against engine with custom implementations to fetch
         kernel name and language from the notebook object

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -3,14 +3,15 @@ import io
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from copy import deepcopy
+from unittest.mock import patch, ANY
 
 from functools import partial
 from pathlib import Path
 
 from nbformat import validate
 
-from .. import engines
+from .. import engines, translators, parameterize
 from ..log import logger
 from ..iorw import load_notebook_node
 from ..utils import chdir
@@ -386,3 +387,53 @@ class TestMinimalNotebook(unittest.TestCase):
         execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
         nb = load_notebook_node(result_path)
         validate(nb)
+
+
+class TestExecuteWithCustomEngine(unittest.TestCase):
+    """Tests execute against engine with custom implementations to fetch
+    kernel name and language from the notebook object
+    """
+    class CustomEngine(engines.Engine):
+        @classmethod
+        def execute_managed_notebook(cls, nb_man, kernel_name, **kwargs):
+            pass
+
+        @classmethod
+        def nb_kernel_name(cls, nb, name=None):
+            return "my_custom_kernel"
+
+        @classmethod
+        def nb_language(cls, nb, language=None):
+            return "my_custom_language"
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.notebook_path = get_notebook_path('simple_execute.ipynb')
+        self.nb_test_executed_fname = os.path.join(
+            self.test_dir, 'output_{}'.format('simple_execute.ipynb')
+        )
+
+        self.engine_name = "custom_engine"
+        self._orig_papermill_engines = deepcopy(engines.papermill_engines)
+        self._orig_translators = deepcopy(translators.papermill_translators)
+        engines.papermill_engines.register(
+            "custom_engine", self.CustomEngine
+        )
+        translators.papermill_translators.register("my_custom_language", translators.PythonTranslator())
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+        engines.papermill_engines = self._orig_papermill_engines
+        translators.papermill_translators = self._orig_translators
+
+    @patch.object(CustomEngine, "execute_managed_notebook", wraps=CustomEngine.execute_managed_notebook)
+    @patch(parameterize.__name__ + ".translate_parameters", wraps=translators.translate_parameters)
+    def test_custom_kernel_name_and_language(self, translate_parameters, execute_managed_notebook):
+        execute_notebook(
+            self.notebook_path,
+            self.nb_test_executed_fname,
+            engine_name=self.engine_name,
+            parameters={"msg": "fake msg"},
+        )
+        self.assertEqual(execute_managed_notebook.call_args[0], (ANY, "my_custom_kernel"))
+        self.assertEqual(translate_parameters.call_args[0], (ANY, 'my_custom_language', {"msg": "fake msg"}, ANY))

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -390,11 +390,6 @@ class TestMinimalNotebook(unittest.TestCase):
 
 
 class TestExecuteWithCustomEngine(unittest.TestCase):
-    class SimpleEngine(engines.Engine):
-        @classmethod
-        def execute_managed_notebook(cls, nb_man, kernel_name, **kwargs):
-            pass
-
     class CustomEngine(engines.Engine):
         @classmethod
         def execute_managed_notebook(cls, nb_man, kernel_name, **kwargs):
@@ -418,9 +413,6 @@ class TestExecuteWithCustomEngine(unittest.TestCase):
         self._orig_papermill_engines = deepcopy(engines.papermill_engines)
         self._orig_translators = deepcopy(translators.papermill_translators)
         engines.papermill_engines.register(
-            "simple_engine", self.SimpleEngine
-        )
-        engines.papermill_engines.register(
             "custom_engine", self.CustomEngine
         )
         translators.papermill_translators.register("my_custom_language", translators.PythonTranslator())
@@ -429,18 +421,6 @@ class TestExecuteWithCustomEngine(unittest.TestCase):
         shutil.rmtree(self.test_dir)
         engines.papermill_engines = self._orig_papermill_engines
         translators.papermill_translators = self._orig_translators
-
-    @patch.object(SimpleEngine, "execute_managed_notebook", wraps=SimpleEngine.execute_managed_notebook)
-    def test_default_kernel_name_and_language(self, execute_managed_notebook):
-        """Tests that the default implementations to fetch kernel name and language are used if they are not implemented
-        in the engine provided"""
-        execute_notebook(
-            self.notebook_path,
-            self.nb_test_executed_fname,
-            engine_name="simple_engine",
-            parameters={"msg": "fake msg"},
-        )
-        self.assertEqual(execute_managed_notebook.call_args[0], (ANY, "python3"))
 
     @patch.object(CustomEngine, "execute_managed_notebook", wraps=CustomEngine.execute_managed_notebook)
     @patch(parameterize.__name__ + ".translate_parameters", wraps=translators.translate_parameters)


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

## Context behind this PR
At Noteable, we came across a use-case where parametrized executions with a [custom Noteable engine](https://github.com/noteable-io/papermill-origami) were not working because papermill expects the `kernel_name` to be present in the `kernelspec` of the notebook if `kernel_name` was not explicitly passed in as a kwarg. It throws a `ValueError` with the message "No kernel name found in notebook and no override provided.". Like so,

```
>>> pm.execute_notebook(
        f'noteable://{file_id}', 
        'foo.ipynb', 
        engine_name='noteable'
        # custom Noteable kwargs
        file=file, 
        client=client, 
        log_output=True,
    )
...
ValueError: No kernel name found in notebook and no override provided.
```

## What does this PR do?

This PR allows the extended engine to define custom business logic for the following:
- fetching kernel name from the notebook object by implementing the `nb_kernel_name` method
- fetching programming language from the notebook object by implementing the `nb_language` method
