### PR TITLE
add dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Basic dependabot.yml file with minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "monthly"
+    # Labels on pull requests for version updates only
+    labels:
+      - "ci"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    # Allow up to 5 open pull requests for GitHub Actions
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What does this PR do?

This will help to keep the CI/CD updated.
Dependable is a GitHub application that, based on config checks if some GitHub action can be updated to the latest version if yes, it will create a PR with this update some it will also verify that the update still works with the repository...

See for example here: https://github.com/Borda/docker_sample/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot