### PR TITLE
Add Minimum Version of Tenacity For Resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ nbclient >= 0.2.0
 tqdm >= 4.32.2
 requests
 entrypoints
-tenacity
+tenacity >= 5.0.2


### PR DESCRIPTION
Requires a minimum version of `tenacity`.

In version `5.0.1` and below of `tenacity`, the `wait_exponential` method does not take a kwarg of `min`.
https://github.com/jd/tenacity/blob/5.0.1/tenacity/wait.py#L136-L152. This was resolved in the following version `5.0.2`.

However, `papermill` references this kwarg here: https://github.com/nteract/papermill/blob/main/papermill/iorw.py#L330-L333. To ensure proper dependency resolution, the resolved `tenacity` version should be at least `5.0.2` for this particular code to execute successfully.