### PR TITLE
Always upgrade the Notebook before writing into it

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -223,6 +223,9 @@ def raise_for_execution_errors(nb, output_path):
         error_anchor_cell = nbformat.v4.new_markdown_cell(ERROR_ANCHOR_MSG)
         error_anchor_cell.metadata['tags'] = [ERROR_MARKER_TAG]
 
+        # Upgrade the Notebook to the latest v4 before writing into it
+        nb = nbformat.v4.upgrade(nb)
+
         # put the anchor before the cell with the error, before all the indices change due to the
         # heading-prepending
         nb.cells.insert(error.cell_index, error_anchor_cell)

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -89,6 +89,9 @@ def parameterize_notebook(
     # Generate parameter content based on the kernel_name
     param_content = translate_parameters(kernel_name, language, parameters, comment)
 
+    # Upgrade the Notebook to the latest v4 before writing into it
+    nb = nbformat.v4.upgrade(nb)
+
     newcell = nbformat.v4.new_code_cell(source=param_content)
     newcell.metadata['tags'] = ['injected-parameters']
 


### PR DESCRIPTION
## What does this PR do?

Always upgrade the Notebook to the latest v4 before writing new cells into it. This prevents *e.g.* having a malformed Notebook with a mix of `v4.4` cells with `v4.5` cells.

Fixes #686
