### PR TITLE
Use “parameterize” spelling

### DIFF
--- a/docs/usage-inspect.rst
+++ b/docs/usage-inspect.rst
@@ -22,7 +22,7 @@ The `inspect_notebook` function can be called to inspect a notebook:
    pm.inspect_notebook('path/to/input.ipynb')
 
 .. note::
-    If your path is parametrized, you can pass those parameters in a dictionary
+    If your path is parameterized, you can pass those parameters in a dictionary
     as second parameter:
 
     ``inspect_notebook('path/to/input_{month}.ipynb', parameters={month='Feb'})``

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='papermill',
     version=version(),
-    description='Parametrize and run Jupyter and nteract Notebooks',
+    description='Parameterize and run Jupyter and nteract Notebooks',
     author='nteract contributors',
     author_email='nteract@googlegroups.com',
     license='BSD',


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

When not specifically referring to the [`parametrize` package](https://pypi.org/project/parametrize/), this PR ensures the standard spelling “parameterize” is used throughout the documentation and metadata.

This is consistent with the GitHub project page summary and with the first sentence of README.md.

Fixes **(no issue filed)**
