### PR TITLE
Fix: PapermillNotebookClient.execute hangs

### DIFF
--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -42,9 +42,9 @@ class PapermillNotebookClient(NotebookClient):
 
         with self.setup_kernel(**kwargs):
             self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
-            self.papermill_execute_cells()
             info_msg = self.wait_for_reply(self.kc.kernel_info())
             self.nb.metadata['language_info'] = info_msg['content']['language_info']
+            self.papermill_execute_cells()
             self.set_widgets_metadata()
 
         return self.nb


### PR DESCRIPTION
Potential fix for https://github.com/nteract/papermill/issues/711

This issue occurred for me with the following configuration

* python 3.7.15
* Debian 11
* gitlab-runner 16.0.1
* papermill-2.4.0
* nbclient-0.7.4
* nbformat-5.8.0
* pyzmq-25.1.1b1

I did not manage to reproduce it manually but CI tests using papermill were hanging in `PapermillNotebookClient.execute` after it finished executing all cells. More precisely `wait_for_reply(self.kc.kernel_info())` hangs:

```python
src/ewokscore/notebooktask.py:37: in run
    kernel_name=kernel_name,
src/ewokscore/notebooktask.py:56: in _execute_notebook
    execution_timeout=60,
/usr/local/lib/python3.7/site-packages/papermill/execute.py:124: in execute_notebook
    **engine_kwargs
/usr/local/lib/python3.7/site-packages/papermill/engines.py:49: in execute_notebook_with_engine
    return self.get_engine(engine_name).execute_notebook(nb, kernel_name, **kwargs)
/usr/local/lib/python3.7/site-packages/papermill/engines.py:367: in execute_notebook
    cls.execute_managed_notebook(nb_man, kernel_name, log_output=log_output, **kwargs)
/usr/local/lib/python3.7/site-packages/papermill/engines.py:436: in execute_managed_notebook
    return PapermillNotebookClient(nb_man, **final_kwargs).execute()
/usr/local/lib/python3.7/site-packages/papermill/clientwrap.py:46: in execute
    info_msg = self.wait_for_reply(self.kc.kernel_info())
/usr/local/lib/python3.7/site-packages/jupyter_core/utils/__init__.py:98: in wrapped
    return loop.run_until_complete(inner)
/usr/local/lib/python3.7/asyncio/base_events.py:587: in run_until_complete
    return future.result()
/usr/local/lib/python3.7/site-packages/nbclient/client.py:879: in async_wait_for_reply
    await self._async_handle_timeout(timeout, cell)
```

Full trace: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/jobs/692249

https://github.com/nteract/papermill/blob/3ad2dacbf539967cfed46bfa8516afbb8a120849/papermill/clientwrap.py#L42-L48

When comparing this to the original I noticed that fetching `language_info` was done before executing the cells:

https://github.com/jupyter/nbclient/blob/2d23e28e81273d4bbc56d060e1d0078f25360b43/nbclient/client.py#L693

Fetching `language_info` before executing the cells fixed my CI problem (no more hanging).