### PR TITLE
Changed parameter inspection to reuse utils funcs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Changed parameter inspection to raise the same error messages as other pathways for missing kernel name and language
+
 ## 2.5.0
 
 - Added support for python 3.11 and 3.12 [PR #733](https://github.com/nteract/papermill/pull/733)

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -91,7 +91,7 @@ def execute_notebook(
 
         # Parameterize the Notebook.
         if parameters:
-            parameter_predefined = _infer_parameters(nb)
+            parameter_predefined = _infer_parameters(nb, name=kernel_name, language=language)
             parameter_predefined = {p.name for p in parameter_predefined}
             for p in parameters:
                 if p not in parameter_predefined:

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -7,7 +7,7 @@ from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd
 from .log import logger
 from .parameterize import add_builtin_parameters, parameterize_path
 from .translators import papermill_translators
-from .utils import any_tagged_cell, find_first_tagged_cell_index
+from .utils import any_tagged_cell, find_first_tagged_cell_index, nb_kernel_name, nb_language
 
 
 def _open_notebook(notebook_path, parameters):
@@ -19,7 +19,7 @@ def _open_notebook(notebook_path, parameters):
         return load_notebook_node(input_path)
 
 
-def _infer_parameters(nb):
+def _infer_parameters(nb, name=None, language=None):
     """Infer the notebook parameters.
 
     Parameters
@@ -38,8 +38,9 @@ def _infer_parameters(nb):
     if parameter_cell_idx < 0:
         return params
     parameter_cell = nb.cells[parameter_cell_idx]
-    kernel_name = nb.metadata.kernelspec.name
-    language = nb.metadata.kernelspec.language
+
+    kernel_name = nb_kernel_name(nb, name)
+    language = nb_language(nb, language)
 
     translator = papermill_translators.find_translator(kernel_name, language)
     try:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Reuses the util methods for inspection that require user overrides when critical metadata is missing.

Fixes #735 
