### PR TITLE
Implement --remove-tagged-cells

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -63,6 +63,9 @@ def print_papermill_version(ctx, param, value):
     '--parameters_base64', '-b', multiple=True, help='Base64 encoded YAML string as parameters.'
 )
 @click.option(
+    '--remove-tagged-cells', type=str, help='Remove cells with the specified tag before execution.'
+)
+@click.option(
     '--inject-input-path',
     is_flag=True,
     default=False,
@@ -166,6 +169,7 @@ def papermill(
     parameters_file,
     parameters_yaml,
     parameters_base64,
+    remove_tagged_cells,
     inject_input_path,
     inject_output_path,
     inject_paths,
@@ -259,6 +263,7 @@ def papermill(
             request_save_on_cell_execute=request_save_on_cell_execute,
             autosave_cell_every=autosave_cell_every,
             prepare_only=prepare_only,
+            remove_tagged_cells=remove_tagged_cells,
             kernel_name=kernel,
             language=language,
             progress_bar=progress_bar,

--- a/papermill/tests/notebooks/simple_with_tags.ipynb
+++ b/papermill/tests/notebooks/simple_with_tags.ipynb
@@ -22,7 +22,7 @@
    "id": "7979d49a-abb1-4815-9534-ad76e4505b56",
    "metadata": {
     "tags": [
-     "skipcell"
+     "assigncell"
     ]
    },
    "outputs": [],
@@ -35,7 +35,9 @@
    "execution_count": null,
    "id": "778581dd-f385-4039-be97-4050615fa271",
    "metadata": {
-    "tags": []
+    "tags": [
+     "printcell"
+    ]
    },
    "outputs": [],
    "source": [

--- a/papermill/tests/notebooks/simple_with_tags.ipynb
+++ b/papermill/tests/notebooks/simple_with_tags.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a0730871-38e0-4f31-9466-1a117965e5a1",
+   "metadata": {},
+   "source": [
+    "### Markdown cell"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "00000b67-913e-459a-80dc-2520b2483d7d",
+   "metadata": {},
+   "source": [
+    "Raw cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7979d49a-abb1-4815-9534-ad76e4505b56",
+   "metadata": {
+    "tags": [
+     "skipcell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "a = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "778581dd-f385-4039-be97-4050615fa271",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(a)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -135,6 +135,49 @@ class TestNotebookHelpers(unittest.TestCase):
                 ['# Parameters', r'foo = "do\\ not\\ crash"', ''],
             )
 
+    def test_remove_tagged_cells(self):
+        notebook_name = 'simple_with_tags.ipynb'
+
+        # Default case, no cells are skipped
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), nb_test_executed_fname, {})
+        output_nb = load_notebook_node(nb_test_executed_fname)
+        assert len(output_nb.cells) == 4
+
+        # If a nonexistent tag is specified, no cells are skipped
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(
+            get_notebook_path(notebook_name),
+            nb_test_executed_fname,
+            {},
+            remove_tagged_cells="nonexistent",
+        )
+        output_nb = load_notebook_node(nb_test_executed_fname)
+        assert len(output_nb.cells) == 4
+
+        # If cells with the 'printcell' tag are skipped, the output notebook is missing one cell
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(
+            get_notebook_path(notebook_name),
+            nb_test_executed_fname,
+            {},
+            remove_tagged_cells="printcell",
+        )
+        output_nb = load_notebook_node(nb_test_executed_fname)
+        assert len(output_nb.cells) == 3
+
+        # If cells with the 'assigncell' tag are skipped, the execution raises an error
+        nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        with self.assertRaises(PapermillExecutionError):
+            execute_notebook(
+                get_notebook_path(notebook_name),
+                nb_test_executed_fname,
+                {},
+                remove_tagged_cells="assigncell",
+            )
+        output_nb = load_notebook_node(nb_test_executed_fname)
+        self.assertEqual(output_nb.cells[4].outputs[0]["evalue"], "name 'a' is not defined")
+
 
 class TestBrokenNotebook1(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This implements a new --remote-tagged-cells option as described by @MSeal in https://github.com/nteract/papermill/issues/429#issuecomment-642806948. The idea of the current implementation is to keep it as simple as possible – only being able to specify a single tag and requiring an exact match (no regular expressions etc). My personal use case for this is being able to run notebooks with/without diagnostic plotting but there are other use cases described in https://github.com/nteract/papermill/issues/429.

If the maintainers are on board with this PR so far, I can add documentation and anything else required.

One thought I had was that perhaps this option would read more clearly as ``--remove-cells-with-tag`` otherwise it sounds like a boolean option, and also doesn't make it clear that a single tag is what should be passed in. What do people think about this?