### PR TITLE
Relax precommit config to not autofix prs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.8
 
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: quarterly
   # submodules: true


### PR DESCRIPTION
As we look to modernize the repo's packaging, it would be helpful for the autofix feature of pre-commit to be turned off. I like the bot providing feedback. I'm not as fond of the PR being changed.
