### PR TITLE
Use f-strings where possible

### DIFF
--- a/papermill/adl.py
+++ b/papermill/adl.py
@@ -39,12 +39,7 @@ class ADL:
         """Returns a list of the files under the specified path"""
         (store_name, path) = self._split_url(url)
         adapter = self._create_adapter(store_name)
-        return [
-            "adl://{store_name}.azuredatalakestore.net/{path_to_child}".format(
-                store_name=store_name, path_to_child=path_to_child
-            )
-            for path_to_child in adapter.ls(path)
-        ]
+        return [f"adl://{store_name}.azuredatalakestore.net/{path_to_child}" for path_to_child in adapter.ls(path)]
 
     def read(self, url):
         """Read storage at a given url"""

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -26,11 +26,7 @@ OUTPUT_PIPED = not sys.stdout.isatty()
 def print_papermill_version(ctx, param, value):
     if not value:
         return
-    print(
-        "{version} from {path} ({pyver})".format(
-            version=papermill_version, path=__file__, pyver=platform.python_version()
-        )
-    )
+    print(f"{papermill_version} from {__file__} ({platform.python_version()})")
     ctx.exit()
 
 

--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -41,7 +41,7 @@ class PapermillNotebookClient(NotebookClient):
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
         with self.setup_kernel(**kwargs):
-            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
+            self.log.info(f"Executing notebook with kernel: {self.kernel_name}")
             self.papermill_execute_cells()
             info_msg = self.wait_for_reply(self.kc.kernel_info())
             self.nb.metadata['language_info'] = info_msg['content']['language_info']

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -33,8 +33,8 @@ class PapermillExecutionError(PapermillException):
         # when called with str(). In order to maintain compatibility with previous versions which
         # passed only the message to the superclass constructor, __str__ method is implemented to
         # provide the same result as was produced in the past.
-        message = "\n" + 75 * "-" + "\n"
-        message += 'Exception encountered at "In [%s]":\n' % str(self.exec_count)
+        message = f"\n{75 * '-'}\n"
+        message += f'Exception encountered at "In [{self.exec_count}]":\n'
         message += "\n".join(self.traceback)
         message += "\n"
         return message

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -80,8 +80,8 @@ def execute_notebook(
     input_path = parameterize_path(input_path, path_parameters)
     output_path = parameterize_path(output_path, path_parameters)
 
-    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
-    logger.info("Output Notebook: %s" % get_pretty_path(output_path))
+    logger.info(f"Input Notebook:  {get_pretty_path(input_path)}")
+    logger.info(f"Output Notebook: {get_pretty_path(output_path)}")
     with local_file_io_cwd():
         if cwd is not None:
             logger.info(f"Working directory: {get_pretty_path(cwd)}")
@@ -169,13 +169,11 @@ ERROR_MARKER_TAG = "papermill-error-cell-tag"
 ERROR_STYLE = 'style="color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;"'
 
 ERROR_MESSAGE_TEMPLATE = (
-    '<span ' + ERROR_STYLE + '>'
-    "An Exception was encountered at '<a href=\"#papermill-error-cell\">In [%s]</a>'."
-    '</span>'
+    f"<span {ERROR_STYLE}>An Exception was encountered at '<a href=\"#papermill-error-cell\">In [%s]</a>'.</span>"
 )
 
 ERROR_ANCHOR_MSG = (
-    '<span id="papermill-error-cell" ' + ERROR_STYLE + '>'
+    f'<span id="papermill-error-cell" {ERROR_STYLE}>'
     'Execution using papermill encountered an exception here and stopped:'
     '</span>'
 )

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -13,7 +13,7 @@ from .utils import any_tagged_cell, find_first_tagged_cell_index, nb_kernel_name
 def _open_notebook(notebook_path, parameters):
     path_parameters = add_builtin_parameters(parameters)
     input_path = parameterize_path(notebook_path, path_parameters)
-    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+    logger.info(f"Input Notebook:  {get_pretty_path(input_path)}")
 
     with local_file_io_cwd():
         return load_notebook_node(input_path)
@@ -78,14 +78,14 @@ def display_notebook_help(ctx, notebook_path, parameters):
             if type_repr == "None":
                 type_repr = "Unknown type"
 
-            definition = "  {}: {} (default {})".format(p["name"], type_repr, p["default"])
+            definition = f"  {p['name']}: {type_repr} (default {p['default']})"
             if len(definition) > 30:
                 if len(p["help"]):
-                    param_help = "".join((definition, "\n", 34 * " ", p["help"]))
+                    param_help = f"{definition}\n{34 * ' '}{p['help']}"
                 else:
                     param_help = definition
             else:
-                param_help = "{:<34}{}".format(definition, p["help"])
+                param_help = f"{definition:<34}{p['help']}"
             click.echo(param_help)
     else:
         click.echo(

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -146,8 +146,8 @@ class PapermillIO:
 
         if extensions:
             if not fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*.*'):
-                warnings.warn("the file is not specified with any extension : " + os.path.basename(path))
-            elif not any(fnmatch.fnmatch(os.path.basename(path).split('?')[0], '*' + ext) for ext in extensions):
+                warnings.warn(f"the file is not specified with any extension : {os.path.basename(path)}")
+            elif not any(fnmatch.fnmatch(os.path.basename(path).split('?')[0], f"*{ext}") for ext in extensions):
                 warnings.warn(f"The specified file ({path}) does not end in one of {extensions}")
 
         local_handler = None
@@ -380,7 +380,7 @@ class GithubHandler:
         repo_id = splits[4]
         ref_id = splits[6]
         sub_path = '/'.join(splits[7:])
-        repo = self._get_client().get_repo(org_id + '/' + repo_id)
+        repo = self._get_client().get_repo(f"{org_id}/{repo_id}")
         content = repo.get_contents(sub_path, ref=ref_id)
         return content.decoded_content
 

--- a/papermill/s3.py
+++ b/papermill/s3.py
@@ -102,7 +102,7 @@ class Key:
         self.etag = etag
         if last_modified:
             try:
-                self.last_modified = last_modified.isoformat().split('+')[0] + '.000Z'
+                self.last_modified = f"{last_modified.isoformat().split('+')[0]}.000Z"
             except ValueError:
                 self.last_modified = last_modified
         self.storage_class = storage_class
@@ -158,14 +158,13 @@ class S3:
         return self._clean(bucket).split('/', 1)[0]
 
     def _clean(self, name):
-        if name.startswith('s3n:'):
-            name = 's3:' + name[4:]
+        name = self._clean_s3(name)
         if self._is_s3(name):
             return name[5:]
         return name
 
     def _clean_s3(self, name):
-        return 's3:' + name[4:] if name.startswith('s3n:') else name
+        return f"s3:{name[4:]}" if name.startswith('s3n:') else name
 
     def _get_key(self, name):
         if isinstance(name, Key):
@@ -346,7 +345,7 @@ class S3:
                 if err:
                     raise Exception
                 else:
-                    raise AwsError('Failed to fully read [%s]' % source.name)
+                    raise AwsError(f'Failed to fully read [{source.name}]')
 
             if undecoded:
                 assert encoding is not None  # only time undecoded is set

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -107,17 +107,17 @@ class TestCLI(unittest.TestCase):
         kwargs.update(new_kwargs)
         return kwargs
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-p', 'foo', 'bar', '--parameters', 'baz', '42'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': 42}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_raw(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-r', 'foo', 'bar', '--parameters_raw', 'baz', '42'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': '42'}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_file(self, execute_patch):
         extra_args = ['-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file]
         self.runner.invoke(papermill, self.default_args + extra_args)
@@ -133,7 +133,7 @@ class TestCLI(unittest.TestCase):
             )
         )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_yaml(self, execute_patch):
         self.runner.invoke(
             papermill,
@@ -141,12 +141,12 @@ class TestCLI(unittest.TestCase):
         )
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'foo': 'bar', 'foo2': ['baz']}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_yaml_date(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-y', 'a_date: 2019-01-01'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_empty(self, execute_patch):
         # "#empty" ---base64--> "I2VtcHR5"
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -171,7 +171,7 @@ class TestCLI(unittest.TestCase):
                 )
             )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_yaml_override(self, execute_patch):
         self.runner.invoke(
             papermill,
@@ -184,7 +184,7 @@ class TestCLI(unittest.TestCase):
             )
         )
 
-    @patch(cli.__name__ + '.execute_notebook', side_effect=nbclient.exceptions.DeadKernelError("Fake"))
+    @patch(f"{cli.__name__}.execute_notebook", side_effect=nbclient.exceptions.DeadKernelError("Fake"))
     def test_parameters_dead_kernel(self, execute_patch):
         result = self.runner.invoke(
             papermill,
@@ -192,7 +192,7 @@ class TestCLI(unittest.TestCase):
         )
         assert result.exit_code == 138
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_base64(self, execute_patch):
         extra_args = [
             '--parameters_base64',
@@ -203,26 +203,26 @@ class TestCLI(unittest.TestCase):
         self.runner.invoke(papermill, self.default_args + extra_args)
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'foo': 1, 'bar': 2}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_base64_date(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--parameters_base64', 'YV9kYXRlOiAyMDE5LTAxLTAx'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'}))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_inject_input_path(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-input-path'])
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(parameters={'PAPERMILL_INPUT_PATH': 'input.ipynb'})
         )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_inject_output_path(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-output-path'])
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(parameters={'PAPERMILL_OUTPUT_PATH': 'output.ipynb'})
         )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_inject_paths(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--inject-paths'])
         execute_patch.assert_called_with(
@@ -234,42 +234,42 @@ class TestCLI(unittest.TestCase):
             )
         )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_engine(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--engine', 'engine-that-could'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(engine_name='engine-that-could'))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_prepare_only(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--prepare-only'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(prepare_only=True))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_kernel(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-k', 'python3'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(kernel_name='python3'))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_language(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-l', 'python'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(language='python'))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_set_cwd(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--cwd', 'a/path/here'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(cwd='a/path/here'))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_progress_bar(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--progress-bar'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(progress_bar=True))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_no_progress_bar(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--no-progress-bar'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(progress_bar=False))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_log_output(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-output'])
         execute_patch.assert_called_with(
@@ -279,61 +279,61 @@ class TestCLI(unittest.TestCase):
             )
         )
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_log_output_plus_progress(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-output', '--progress-bar'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(log_output=True, progress_bar=True))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_no_log_output(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--no-log-output'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(log_output=False))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_log_level(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--log-level', 'WARNING'])
         # TODO: this does not actually test log-level being set
         execute_patch.assert_called_with(**self.augment_execute_kwargs())
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_start_timeout(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--start-timeout', '123'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_start_timeout_backwards_compatibility(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--start_timeout', '123'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(start_timeout=123))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_execution_timeout(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--execution-timeout', '123'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(execution_timeout=123))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_report_mode(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--report-mode'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(report_mode=True))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_no_report_mode(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['--no-report-mode'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(report_mode=False))
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_version(self, execute_patch):
         self.runner.invoke(papermill, ['--version'])
         execute_patch.assert_not_called()
 
-    @patch(cli.__name__ + '.execute_notebook')
-    @patch(cli.__name__ + '.display_notebook_help')
+    @patch(f"{cli.__name__}.execute_notebook")
+    @patch(f"{cli.__name__}.display_notebook_help")
     def test_help_notebook(self, display_notebook_help, execute_path):
         self.runner.invoke(papermill, ['--help-notebook', 'input_path.ipynb'])
         execute_path.assert_not_called()
         assert display_notebook_help.call_count == 1
         assert display_notebook_help.call_args[0][1] == 'input_path.ipynb'
 
-    @patch(cli.__name__ + '.execute_notebook')
+    @patch(f"{cli.__name__}.execute_notebook")
     def test_many_args(self, execute_patch):
         extra_args = [
             '-f',
@@ -535,4 +535,4 @@ def test_stdout_file(tmpdir):
     assert not err
 
     with open(str(stdout_file)) as fp:
-        assert fp.read() == secret + '\n'
+        assert fp.read() == f"{secret}\n"

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -31,7 +31,7 @@ class TestNotebookHelpers(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    @patch(engines.__name__ + '.PapermillNotebookClient')
+    @patch(f"{engines.__name__}.PapermillNotebookClient")
     def test_start_timeout(self, preproc_mock):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, start_timeout=123)
         args, kwargs = preproc_mock.call_args
@@ -47,7 +47,7 @@ class TestNotebookHelpers(unittest.TestCase):
             msg=f'Expected arguments {expected} are not a subset of actual {actual}',
         )
 
-    @patch(engines.__name__ + '.PapermillNotebookClient')
+    @patch(f"{engines.__name__}.PapermillNotebookClient")
     def test_default_start_timeout(self, preproc_mock):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname)
         args, kwargs = preproc_mock.call_args
@@ -375,7 +375,7 @@ class TestExecuteWithCustomEngine(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
         self.notebook_path = get_notebook_path('simple_execute.ipynb')
-        self.nb_test_executed_fname = os.path.join(self.test_dir, 'output_{}'.format('simple_execute.ipynb'))
+        self.nb_test_executed_fname = os.path.join(self.test_dir, 'output_simple_execute.ipynb')
 
         self._orig_papermill_engines = deepcopy(engines.papermill_engines)
         self._orig_translators = deepcopy(translators.papermill_translators)

--- a/papermill/tests/test_s3.py
+++ b/papermill/tests/test_s3.py
@@ -108,12 +108,12 @@ def test_prefix_defaults():
 
 def test_prefix_str(bucket_sqs):
     p1 = Prefix(bucket_sqs, 'sqs_prefix_test', 'sqs')
-    assert str(p1) == 's3://' + str(bucket_sqs) + '/sqs_prefix_test'
+    assert str(p1) == f"s3://{str(bucket_sqs)}/sqs_prefix_test"
 
 
 def test_prefix_repr(bucket_sqs):
     p1 = Prefix(bucket_sqs, 'sqs_prefix_test', 'sqs')
-    assert repr(p1) == 's3://' + str(bucket_sqs) + '/sqs_prefix_test'
+    assert repr(p1) == f"s3://{str(bucket_sqs)}/sqs_prefix_test"
 
 
 def test_key_init():
@@ -174,7 +174,7 @@ def s3_client():
     yield S3()
     try:
         client.delete_object(Bucket=test_bucket_name, Key=test_file_path)
-        client.delete_object(Bucket=test_bucket_name, Key=test_file_path + '.txt')
+        client.delete_object(Bucket=test_bucket_name, Key=f"{test_file_path}.txt")
         client.delete_object(Bucket=test_bucket_name, Key=test_empty_file_path)
     except Exception:
         pass

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -311,7 +311,7 @@ class ScalaTranslator(Translator):
     @classmethod
     def translate_int(cls, val):
         strval = cls.translate_raw_str(val)
-        return strval + "L" if (val > 2147483647 or val < -2147483648) else strval
+        return f"{strval}L" if (val > 2147483647 or val < -2147483648) else strval
 
     @classmethod
     def translate_dict(cls, val):
@@ -413,7 +413,7 @@ class CSharpTranslator(Translator):
     @classmethod
     def translate_int(cls, val):
         strval = cls.translate_raw_str(val)
-        return strval + "L" if (val > 2147483647 or val < -2147483648) else strval
+        return f"{strval}L" if (val > 2147483647 or val < -2147483648) else strval
 
     @classmethod
     def translate_dict(cls, val):
@@ -449,7 +449,7 @@ class FSharpTranslator(Translator):
     @classmethod
     def translate_int(cls, val):
         strval = cls.translate_raw_str(val)
-        return strval + "L" if (val > 2147483647 or val < -2147483648) else strval
+        return f"{strval}L" if (val > 2147483647 or val < -2147483648) else strval
 
     @classmethod
     def translate_dict(cls, val):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ here = os.path.abspath(local_path)
 
 
 def version():
-    with open(here + '/papermill/version.py') as ver:
+    with open(f"{here}/papermill/version.py") as ver:
         for line in ver.readlines():
             if line.startswith('version ='):
                 return line.split(' = ')[-1].strip()[1:-1]


### PR DESCRIPTION
## What does this PR do?

This PR cleans up various uses of `%` or `.format` or ` + ` string interpolation to use f-strings instead, for performance and readability.

Conversion was guided by https://github.com/ikamensh/flynt and hand-checked.