### PR TITLE
Pre-commit fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.8
-
 ci:
   autofix_prs: true
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,6 @@ repos:
       - id: check-docstring-first
       - id: detect-private-key
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
-        name: Upgrade code
-
   #- repo: https://github.com/myint/docformatter
   #  rev: v1.5.0
   #  hooks:
@@ -53,7 +46,7 @@ repos:
           - mdformat_frontmatter
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.4
+    rev: v0.1.8
     hooks:
         - id: ruff
           args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,6 @@ repos:
           - mdformat-gfm
           - mdformat_frontmatter
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      - id: yesqa
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.4
     hooks:

--- a/papermill/adl.py
+++ b/papermill/adl.py
@@ -39,12 +39,7 @@ class ADL:
         """Returns a list of the files under the specified path"""
         (store_name, path) = self._split_url(url)
         adapter = self._create_adapter(store_name)
-        return [
-            "adl://{store_name}.azuredatalakestore.net/{path_to_child}".format(
-                store_name=store_name, path_to_child=path_to_child
-            )
-            for path_to_child in adapter.ls(path)
-        ]
+        return [f"adl://{store_name}.azuredatalakestore.net/{path_to_child}" for path_to_child in adapter.ls(path)]
 
     def read(self, url):
         """Read storage at a given url"""

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -26,11 +26,7 @@ OUTPUT_PIPED = not sys.stdout.isatty()
 def print_papermill_version(ctx, param, value):
     if not value:
         return
-    print(
-        "{version} from {path} ({pyver})".format(
-            version=papermill_version, path=__file__, pyver=platform.python_version()
-        )
-    )
+    print(f"{papermill_version} from {__file__} ({platform.python_version()})")
     ctx.exit()
 
 

--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -59,8 +59,8 @@ class PapermillParameterOverwriteWarning(PapermillWarning):
 def missing_dependency_generator(package, dep):
     def missing_dep():
         raise PapermillOptionalDependencyException(
-            "The {package} optional dependency is missing. "
-            "Please run pip install papermill[{dep}] to install this dependency".format(package=package, dep=dep)
+            f"The {package} optional dependency is missing. "
+            f"Please run pip install papermill[{dep}] to install this dependency"
         )
 
     return missing_dep
@@ -69,9 +69,9 @@ def missing_dependency_generator(package, dep):
 def missing_environment_variable_generator(package, env_key):
     def missing_dep():
         raise PapermillOptionalDependencyException(
-            "The {package} optional dependency is present, but the environment "
-            "variable {env_key} is not set. Please set this variable as "
-            "required by {package} on your platform.".format(package=package, env_key=env_key)
+            f"The {package} optional dependency is present, but the environment "
+            f"variable {env_key} is not set. Please set this variable as "
+            f"required by {package} on your platform."
         )
 
     return missing_dep

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -94,7 +94,7 @@ def test_str_path():
             [
                 "Dummy usage",
                 "\nParameters inferred for notebook '{name}':",
-                "\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.",  # noqa
+                "\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.",
             ],
         ),
     ],

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -87,7 +87,7 @@ def test_translate_comment_python(test_input, expected):
             [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")],
         ),
         (
-            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",  # noqa
+            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",
             [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")],
         ),
         (

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -143,7 +143,7 @@ class Translator:
 class PythonTranslator(Translator):
     # Pattern to capture parameters within cell input
     PARAMETER_PATTERN = re.compile(
-        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"  # noqa
+        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
     )
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ ignore-words-list = "dne, compiletime"
 
 
 [tool.ruff]
+target-version = "py38"
 line-length = 120
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
@@ -48,6 +49,7 @@ select = [
 #    "D",  # see: https://pypi.org/project/pydocstyle
 #    "N",  # see: https://pypi.org/project/pep8-naming
     "RUF100",  # unnecessary noqa comment
+    "UP",  # pyupgrade
 ]
 #extend-select = [
 #    "C4",  # see: https://pypi.org/project/flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ select = [
     "I",  # isort
 #    "D",  # see: https://pypi.org/project/pydocstyle
 #    "N",  # see: https://pypi.org/project/pep8-naming
+    "RUF100",  # unnecessary noqa comment
 ]
 #extend-select = [
 #    "C4",  # see: https://pypi.org/project/flake8-comprehensions


### PR DESCRIPTION
## What does this PR do?

This PR cleans up the pre-commit configuration slightly:

* Python 3.8 is no longer required to run the tools
* yesqa isn't necessary, since it's depending on flake8 (the use of which was dropped in #752)
* Ruff has rules for Pyupgrade, so it isn't necessary as a separate hook either

Some of the f-string changes the pyupgrade commit does are also done in #762, so these will conflict slightly.

I didn't enable `ruff-format`, since the current quote style in this repository is mixed, and that's not (yet: https://github.com/astral-sh/ruff/issues/9185) supported by Ruff's formatter.