### PR TITLE
Unmark wheel as universal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,5 @@
 # Migration to pyproject.toml is in progress
 
-# distutils is deprecated and removed in Python 3.12.
-# This block can be removed after the build parameters are added to this file
-[tool.distutils.bdist_wheel]
-universal = true
-
 # Example configuration for Black.
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Universal wheels should work on both Python 2 and 3, and Papermill requires Python 3.8+.

## What does this PR do?

Removes the `universal` marker, since the contents of the wheel aren't universal.