### PR TITLE
Fixes # nbformat to 5.2.0 to cell None type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 pyyaml
-nbformat >= 5.1.2
+nbformat >= 5.2.0
 nbclient >= 0.2.0
 tqdm >= 4.32.2
 requests


### PR DESCRIPTION
Upgrading nbformat, as nbformat==5.1.2 and 5.1.3 causes "AttributeError: 'NoneType' object has no attribute 'cells'" due to upgrading nbformat to v4 `nb = nbformat.v4.upgrade(nb)`

## What does this PR do?

Sets nbformat to a minimum version of 5.2.0 to avoid `no attribute 'cells'"`

Fixes #769 
