### PR TITLE
make progrgress_bar param accept a dict

### DIFF
--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -109,7 +109,14 @@ class NotebookExecutionManager:
             # lazy import due to implicit slow ipython import
             from tqdm.auto import tqdm
 
-            self.pbar = tqdm(total=len(self.nb.cells), unit="cell", desc="Executing")
+            if isinstance(progress_bar, bool):
+                self.pbar = tqdm(total=len(self.nb.cells), unit="cell", desc="Executing")
+            elif isinstance(progress_bar, dict):
+                _progress_bar = { "unit": "cell", "desc": "Executing" }
+                _progress_bar.update(progress_bar)
+                self.pbar = tqdm(total=len(self.nb.cells), **_progress_bar)
+            else:
+                raise TypeError(f"progress_bar must be instance of bool or dict, but actual type '{type(progress_bar)}'.")
 
     def now(self):
         """Helper to return current UTC time"""

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -112,11 +112,13 @@ class NotebookExecutionManager:
             if isinstance(progress_bar, bool):
                 self.pbar = tqdm(total=len(self.nb.cells), unit="cell", desc="Executing")
             elif isinstance(progress_bar, dict):
-                _progress_bar = { "unit": "cell", "desc": "Executing" }
+                _progress_bar = {"unit": "cell", "desc": "Executing"}
                 _progress_bar.update(progress_bar)
                 self.pbar = tqdm(total=len(self.nb.cells), **_progress_bar)
             else:
-                raise TypeError(f"progress_bar must be instance of bool or dict, but actual type '{type(progress_bar)}'.")
+                raise TypeError(
+                    f"progress_bar must be instance of bool or dict, but actual type '{type(progress_bar)}'."
+                )
 
     def now(self):
         """Helper to return current UTC time"""


### PR DESCRIPTION
Fixes #777 (Oh, I unintendedly hit the jackpot🎰)

## What does this PR do?
This pull request is an extension that allows passing arguments to `tqdm` by enabling the `progress_bar` parameter of `execute_notebook` to accept a `dict`.

This pull request maintains compatibility with the current implementation, though it might make the conditional branching a bit messy...

I believe there could be discussions on how to actually enable such specification, as follows.

```python
            # Ensure at least unit and desc.
            # Conversely, it becomes impossible to remove unit and desc.
            elif isinstance(progress_bar, dict):
                _progress_bar = { "unit": "cell", "desc": "Executing" }
                _progress_bar.update(progress_bar)
                self.pbar = tqdm(total=len(self.nb.cells), **_progress_bar)
```

```python
            # Simple and accepts any dictionary.
            # However, it's not intuitive as an empty dictionary is precluded by `if progress_bar:`.
            elif isinstance(progress_bar, dict):
                self.pbar = tqdm(total=len(self.nb.cells), **progress_bar)
```

```python
        # It becomes possible to accept an empty dictionary,
        # but the implementation becomes slightly complicated.
        if isinstance(progress_bar, bool):
            if progress_bar:
                # lazy import due to implicit slow ipython import
                from tqdm.auto import tqdm
                ...
        elif isinstance(progress_bar, dict):
            # lazy import due to implicit slow ipython import
            from tqdm.auto import tqdm
            ...
```