### PR TITLE
raise PapermillExecutionError when CellExecutionError is raised without cell error output

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -196,11 +196,13 @@ def raise_for_execution_errors(nb, output_path):
     """
     error = None
     for index, cell in enumerate(nb.cells):
+        has_sys_exit = False
         # check if there is any cell error output
         if "outputs" in cell:
             for output in cell.outputs:
                 if output.output_type == "error":
                     if output.ename == "SystemExit" and (output.evalue == "" or output.evalue == "0"):
+                        has_sys_exit = True
                         continue
                     error = PapermillExecutionError(
                         cell_index=index,
@@ -213,7 +215,7 @@ def raise_for_execution_errors(nb, output_path):
                     break
 
         # handle the CellExecutionError exceptions raised that didn't produce a cell error output
-        if cell.get("metadata", {}).get("papermill", {}).get("exception") == True:
+        if not has_sys_exit and cell.get("metadata", {}).get("papermill", {}).get("exception") is True:
             error = PapermillExecutionError(
                 cell_index=index,
                 exec_count=cell.execution_count,

--- a/papermill/tests/notebooks/line_magic_error.ipynb
+++ b/papermill/tests/notebooks/line_magic_error.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%undefined-line-magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Cell should not execute.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -327,6 +327,19 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[1].outputs[0].evalue, '')
         self.assertEqual(nb.cells[2].execution_count, None)
 
+    def test_line_magic_error(self):
+        notebook_name = 'line_magic_error.ipynb'
+        result_path = os.path.join(self.test_dir, f'output_{notebook_name}')
+        with self.assertRaises(PapermillExecutionError):
+            execute_notebook(get_notebook_path(notebook_name), result_path)
+        nb = load_notebook_node(result_path)
+        self.assertEqual(nb.cells[0].cell_type, "markdown")
+        self.assertRegex(nb.cells[0].source, r'^<span .*<a href="#papermill-error-cell".*In \[1\].*</span>$')
+        self.assertEqual(nb.cells[0].metadata["tags"], ["papermill-error-cell-tag"])
+        self.assertEqual(nb.cells[2].cell_type, "code")
+        self.assertEqual(nb.cells[2].execution_count, 1)
+        self.assertEqual(nb.cells[3].execution_count, None)
+
 
 class TestNotebookValidation(unittest.TestCase):
     def setUp(self):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -2,9 +2,9 @@ import io
 import json
 import os
 import unittest
+import warnings
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
-import warnings
 
 import nbformat
 import pytest

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -4,6 +4,7 @@ import os
 import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
+import warnings
 
 import nbformat
 import pytest
@@ -137,9 +138,9 @@ class TestPapermillIO(unittest.TestCase):
             self.papermill_io.read("fake/path/fakeinputpath.ipynb1")
 
     def test_read_with_valid_file_extension(self):
-        with pytest.warns(None) as warns:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             self.papermill_io.read("fake/path/fakeinputpath.ipynb")
-        self.assertEqual(len(warns), 0)
 
     def test_read_yaml_with_no_file_extension(self):
         with pytest.warns(UserWarning):


### PR DESCRIPTION
When notebooks with cell / line magics are executed and if the magic command fails, papermill doesn't throw any exception and returns exit code 0. This is because papermill relies on cell error output to raise PapermillExecutionError.

When magic commands fail, CellExecutionError is still thrown and recorded as cell metadata, and notebook execution stops. However, since these errors don't produce any cell error output, no exception is raised.

Changes in this PR check cell metadata for exceptions recorded by papermill (due to CellExecutionError) in addition to cell error outputs and raise PapermillExecutionError in those cases.

fixes https://github.com/nteract/papermill/issues/501, https://github.com/nteract/papermill/issues/381

