### PR TITLE
prevent error override, fix traceback type

### DIFF
--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -215,7 +215,11 @@ def raise_for_execution_errors(nb, output_path):
                     break
 
         # handle the CellExecutionError exceptions raised that didn't produce a cell error output
-        if error is None and not has_sys_exit and cell.get("metadata", {}).get("papermill", {}).get("exception") is True:
+        if (
+            error is None
+            and not has_sys_exit
+            and cell.get("metadata", {}).get("papermill", {}).get("exception") is True
+        ):
             error = PapermillExecutionError(
                 cell_index=index,
                 exec_count=cell.execution_count,

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -215,14 +215,14 @@ def raise_for_execution_errors(nb, output_path):
                     break
 
         # handle the CellExecutionError exceptions raised that didn't produce a cell error output
-        if not has_sys_exit and cell.get("metadata", {}).get("papermill", {}).get("exception") is True:
+        if error is None and not has_sys_exit and cell.get("metadata", {}).get("papermill", {}).get("exception") is True:
             error = PapermillExecutionError(
                 cell_index=index,
                 exec_count=cell.execution_count,
                 source=cell.source,
                 ename="CellExecutionError",
                 evalue="",
-                traceback="",
+                traceback=[],
             )
             break
 


### PR DESCRIPTION
this is in addition to https://github.com/nteract/papermill/pull/786 
- fixing overriding regular error type detection. 
- making traceback an empty list instead of empty string