### PR TITLE
build: Require aiohttp v3.9.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tqdm >= 4.32.2
 requests
 entrypoints
 tenacity >= 5.0.2
-aiohttp ==3.9.2; python_version=="3.12"
+aiohttp >=3.9.0; python_version=="3.12"


### PR DESCRIPTION


## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

* Provide a lower bound of v3.9.0 for aiohttp. (c.f. https://github.com/nteract/papermill/issues/785#issuecomment-2032612755).
* `v3.9.0` was validated in PR https://github.com/nteract/papermill/pull/760
