### PR TITLE
[DOC] update path to requirements for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,4 @@ formats:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
+  - requirements: requirements/docs.txt


### PR DESCRIPTION
## What does this PR do?

RTD builds [haven't succeeded](https://readthedocs.org/projects/papermill/builds/) since docs/requirements.txt was moved in #748, so the latest docs build is for 2.4.0.
