### PR TITLE
Fix log output

### DIFF
--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -32,7 +32,7 @@ class PapermillNotebookClient(NotebookClient):
         """
         super().__init__(nb_man.nb, km=km, raise_on_iopub_timeout=raise_on_iopub_timeout, **kw)
         self.nb_man = nb_man
-        self.log_cell = log_cell if log_cell is not None else kw['log']
+        self.log_cell = log_cell if log_cell is not None else self.log
 
     def execute(self, **kwargs):
         """

--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -88,7 +88,8 @@ class PapermillNotebookClient(NotebookClient):
             content = "".join(output.text)
             if output.name == "stdout":
                 if self.log_output:
-                    self.log.info(content)
+                    sys.stdout.write(content)
+                    sys.stdout.flush()
                 if self.stdout_file:
                     self.stdout_file.write(content)
                     self.stdout_file.flush()

--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -16,7 +16,7 @@ class PapermillNotebookClient(NotebookClient):
     stdout_file = Instance(object, default_value=None).tag(config=True)
     stderr_file = Instance(object, default_value=None).tag(config=True)
 
-    def __init__(self, nb_man, km=None, raise_on_iopub_timeout=True, **kw):
+    def __init__(self, nb_man, km=None, log_cell=None, raise_on_iopub_timeout=True, **kw):
         """Initializes the execution manager.
 
         Parameters
@@ -26,9 +26,13 @@ class PapermillNotebookClient(NotebookClient):
         km : KernerlManager (optional)
             Optional kernel manager. If none is provided, a kernel manager will
             be created.
+        log_cell : logging.Logger (optional)
+            Optional logger to use for logging cell output. If not provided, the `log` argument
+            will be used for cell output.
         """
         super().__init__(nb_man.nb, km=km, raise_on_iopub_timeout=raise_on_iopub_timeout, **kw)
         self.nb_man = nb_man
+        self.log_cell = log_cell if log_cell is not None else kw['log']
 
     def execute(self, **kwargs):
         """
@@ -88,20 +92,20 @@ class PapermillNotebookClient(NotebookClient):
             content = "".join(output.text)
             if output.name == "stdout":
                 if self.log_output:
-                    sys.stdout.write(content)
-                    sys.stdout.flush()
+                    self.log_cell.info(content)
                 if self.stdout_file:
                     self.stdout_file.write(content)
                     self.stdout_file.flush()
             elif output.name == "stderr":
                 if self.log_output:
                     # In case users want to redirect stderr differently, pipe to warning
-                    self.log.warning(content)
+                    self.log_cell.warning(content)
                 if self.stderr_file:
                     self.stderr_file.write(content)
                     self.stderr_file.flush()
         elif self.log_output and ("data" in output and "text/plain" in output.data):
-            self.log.info("".join(output.data['text/plain']))
+            self.log_cell.info("".join(output.data['text/plain']))
+            # self.log.info("".join(output.data['text/plain']))
 
     def process_message(self, *arg, **kwargs):
         output = super().process_message(*arg, **kwargs)

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -9,7 +9,7 @@ import entrypoints
 from .clientwrap import PapermillNotebookClient
 from .exceptions import PapermillException
 from .iorw import write_ipynb
-from .log import logger
+from .log import logger, notebook_logger
 from .utils import merge_kwargs, nb_kernel_name, nb_language, remove_args
 
 
@@ -435,6 +435,7 @@ class NBClientEngine(Engine):
             startup_timeout=start_timeout,
             kernel_name=kernel_name,
             log=logger,
+            log_cell=notebook_logger,
             log_output=log_output,
             stdout_file=stdout_file,
             stderr_file=stderr_file,

--- a/papermill/log.py
+++ b/papermill/log.py
@@ -8,7 +8,7 @@ Logger for notebook output. Is automatically reconfigured on init to
 not auto insert newline characters.
 """
 
-class CustomStreamHandler(logging.StreamHandler):
+class NbOutputStreamHandler(logging.StreamHandler):
     def emit(self, record):
         try:
             msg = self.format(record)
@@ -23,7 +23,7 @@ class CustomStreamHandler(logging.StreamHandler):
 
 def _reconfigure_notebook_logger(l: logging.Logger):
     l.handlers = []
-    custom_handler = CustomStreamHandler()
+    custom_handler = NbOutputStreamHandler()
     l.addHandler(custom_handler)
     formatter = logging.Formatter('%(message)s')
     custom_handler.setFormatter(formatter)

--- a/papermill/log.py
+++ b/papermill/log.py
@@ -2,3 +2,32 @@
 import logging
 
 logger = logging.getLogger('papermill')
+notebook_logger = logging.getLogger('papermill.notebook')
+"""
+Logger for notebook output. Is automatically reconfigured on init to
+not auto insert newline characters.
+"""
+
+class CustomStreamHandler(logging.StreamHandler):
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            # issue 35046: merged two stream.writes into one.
+            stream.write(msg)
+            self.flush()
+        except RecursionError:  # See issue 36272
+            raise
+        except Exception:
+            self.handleError(record) 
+
+def _reconfigure_notebook_logger(l: logging.Logger):
+    l.handlers = []
+    custom_handler = CustomStreamHandler()
+    l.addHandler(custom_handler)
+    formatter = logging.Formatter('%(message)s')
+    custom_handler.setFormatter(formatter)
+    l.propagate = False
+
+_reconfigure_notebook_logger(notebook_logger)
+

--- a/papermill/tests/test_clientwrap.py
+++ b/papermill/tests/test_clientwrap.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import call, patch
-import logging
 
 import nbformat
 

--- a/papermill/tests/test_clientwrap.py
+++ b/papermill/tests/test_clientwrap.py
@@ -1,34 +1,36 @@
 import unittest
 from unittest.mock import call, patch
+import logging
 
 import nbformat
 
 from ..clientwrap import PapermillNotebookClient
 from ..engines import NotebookExecutionManager
-from ..log import logger
+from ..log import logger, notebook_logger
 from . import get_notebook_path
+
 
 
 class TestPapermillClientWrapper(unittest.TestCase):
     def setUp(self):
         self.nb = nbformat.read(get_notebook_path('test_logging.ipynb'), as_version=4)
         self.nb_man = NotebookExecutionManager(self.nb)
-        self.client = PapermillNotebookClient(self.nb_man, log=logger, log_output=True)
+        self.client = PapermillNotebookClient(self.nb_man, log=logger, log_cell=notebook_logger, log_output=True)
 
     def test_logging_stderr_msg(self):
-        with patch.object(logger, 'warning') as warning_mock:
+        with patch.object(notebook_logger, 'warning') as warning_mock:
             for output in self.nb.cells[0].get("outputs", []):
                 self.client.log_output_message(output)
             warning_mock.assert_called_once_with("INFO:test:test text\n")
 
     def test_logging_stdout_msg(self):
-        with patch.object(logger, 'info') as info_mock:
+        with patch.object(notebook_logger, 'info') as info_mock:
             for output in self.nb.cells[1].get("outputs", []):
                 self.client.log_output_message(output)
             info_mock.assert_called_once_with("hello world\n")
 
     def test_logging_data_msg(self):
-        with patch.object(logger, 'info') as info_mock:
+        with patch.object(notebook_logger, 'info') as info_mock:
             for output in self.nb.cells[2].get("outputs", []):
                 self.client.log_output_message(output)
             info_mock.assert_has_calls(

--- a/papermill/tests/test_engines.py
+++ b/papermill/tests/test_engines.py
@@ -9,7 +9,7 @@ from nbformat.notebooknode import NotebookNode
 from .. import engines, exceptions
 from ..engines import Engine, NBClientEngine, NotebookExecutionManager
 from ..iorw import load_notebook_node
-from ..log import logger
+from ..log import logger, notebook_logger
 from . import get_notebook_path
 
 
@@ -434,39 +434,50 @@ class TestNBClientEngine(unittest.TestCase):
     def test_nb_convert_log_outputs(self):
         with patch.object(logger, 'info') as info_mock:
             with patch.object(logger, 'warning') as warning_mock:
-                with patch.object(NotebookExecutionManager, 'save'):
-                    NBClientEngine.execute_notebook(
-                        self.nb,
-                        'python',
-                        output_path='foo.ipynb',
-                        progress_bar=False,
-                        log_output=True,
-                    )
-                    info_mock.assert_has_calls(
-                        [
-                            call('Executing notebook with kernel: python'),
-                            call('Executing Cell 1---------------------------------------'),
-                            call('Ending Cell 1------------------------------------------'),
-                            call('Executing Cell 2---------------------------------------'),
-                            call('None\n'),
-                            call('Ending Cell 2------------------------------------------'),
-                        ]
-                    )
-                    warning_mock.is_not_called()
+                with patch.object(notebook_logger, 'info') as notebook_info_mock:
+                    with patch.object(notebook_logger, 'warning') as notebook_warning_mock:
+                        with patch.object(NotebookExecutionManager, 'save'):
+                            NBClientEngine.execute_notebook(
+                                self.nb,
+                                'python',
+                                output_path='foo.ipynb',
+                                progress_bar=False,
+                                log_output=True,
+                            )
+                            info_mock.assert_has_calls(
+                                [
+                                    call('Executing notebook with kernel: python'),
+                                    call('Executing Cell 1---------------------------------------'),
+                                    call('Ending Cell 1------------------------------------------'),
+                                    call('Executing Cell 2---------------------------------------'),
+                                    call('Ending Cell 2------------------------------------------'),
+                                ]
+                            )
+                            notebook_info_mock.assert_has_calls(
+                                [
+                                    call('None\n'),
+                                ]
+                            )
+                            warning_mock.is_not_called()
+                            notebook_warning_mock.is_not_called()
 
     def test_nb_convert_no_log_outputs(self):
         with patch.object(logger, 'info') as info_mock:
             with patch.object(logger, 'warning') as warning_mock:
-                with patch.object(NotebookExecutionManager, 'save'):
-                    NBClientEngine.execute_notebook(
-                        self.nb,
-                        'python',
-                        output_path='foo.ipynb',
-                        progress_bar=False,
-                        log_output=False,
-                    )
-                    info_mock.is_not_called()
-                    warning_mock.is_not_called()
+                with patch.object(notebook_logger, 'info') as notebook_info_mock:
+                    with patch.object(notebook_logger, 'warning') as notebook_warning_mock:
+                        with patch.object(NotebookExecutionManager, 'save'):
+                            NBClientEngine.execute_notebook(
+                                self.nb,
+                                'python',
+                                output_path='foo.ipynb',
+                                progress_bar=False,
+                                log_output=False,
+                            )
+                            info_mock.is_not_called()
+                            warning_mock.is_not_called()
+                            notebook_info_mock.is_not_called()
+                            notebook_warning_mock.is_not_called()
 
 
 class TestEngineRegistration(unittest.TestCase):


### PR DESCRIPTION
Fixes issue where `\n` characters are randomly inserted into the console for stdout messages. This results in non-deterministic output breaking any downstream process.

Connected to #433, #496, #765 

### Current Behaviour:
When there is execution significant time  or async activity between stdout/stderr calls in an output cell, the default logger inserts newline terminators to the papermill console output. This output is different than output as executed in a live notebook client. (See below for screenshots) 

**Example 1:**
**Notebook Output:**
<img width="799" alt="Screenshot 2024-10-18 at 3 17 11 AM" src="https://github.com/user-attachments/assets/8a641385-9488-4134-b3a5-08cbb6242ce7">
**Console Output:**
<img width="582" alt="Screenshot 2024-10-18 at 3 19 02 AM" src="https://github.com/user-attachments/assets/d4016b9a-86fc-4dfe-8d65-ee30667c7a24">

=============

**Example 2:
Notebook Output:**
<img width="808" alt="Screenshot 2024-10-18 at 3 25 31 AM" src="https://github.com/user-attachments/assets/f10568e4-82c8-4cc6-abf6-d0c805e5aa79">
**Console Output:**
<img width="414" alt="Screenshot 2024-10-18 at 3 24 30 AM" src="https://github.com/user-attachments/assets/f1f640b6-198e-4f6e-94e0-6709340244ad">

=============

**Example 3:
Notebook Output:**
<img width="803" alt="Screenshot 2024-10-18 at 3 27 04 AM" src="https://github.com/user-attachments/assets/0dc75355-fb0d-4013-85e5-c6b8094df9a4">
**Console Output:**
<img width="421" alt="Screenshot 2024-10-18 at 3 27 32 AM" src="https://github.com/user-attachments/assets/27fb902d-8f5a-47d3-a43e-ee28a355a32c">


### Expected Behaviour:
When using the `--log-output` option, especially when using the cli, the cell output text from papermill should match the text output when running a notebook in jupyter (or other `.ipynb` client)

### Fix:
Added a secondary logger `notebook_logger` that removes the extraneous terminator from the stream handlers. The notebook logger is only used by cell outputs.

Users can override this behaviour when in using papermill as a library by either resetting the notebook_logger or modifying the parameters when instantiating a Papermill client.

**Output with fix:**
<img width="897" alt="Screenshot 2024-10-18 at 3 47 10 AM" src="https://github.com/user-attachments/assets/324c3134-6fab-42c7-bc53-e7d916bda26c">


### Reasoning behind Fix
The papermill client was using the default `log.info` of the default notebook client for all stdout messages from a notebook when the explicit `—log-output` option is used. This calls the default logger which is built as a logger for syslog. As a result, the log formatter will automatically add `\n` when flushing. 

In Jupyter, the input cell’s stdout and stderr calls are captured and redirected to the notebook’s output cells without additional `\n` characters added in order to preserve the intended output formatting of the notebook’s author. If the author needs to modify their output to ensure it is compatible with whatever downstream tool/process, they should be responsible for making those changes in the notebook itself and trusting that papermill will not alter the cell’s output.

Unfortunately this does not fix the same issue in the underlying nbclient. As a result, the cell output in the output notebook is still different than if you were to run the notebook in a live system (additional newline characters.) 

Excerpt from python `logging` that is causing the issue:
```python
class StreamHandler(Handler):
…
    terminator = '\n'
…
    def emit(self, record):
        """
        Emit a record.

        If a formatter is specified, it is used to format the record.
        The record is then written to the stream with a trailing newline.  If
        exception information is present, it is formatted using
        traceback.print_exception and appended to the stream.  If the stream
        has an 'encoding' attribute, it is used to determine how to do the
        output to the stream.
        """
        try:
            msg = self.format(record)
            stream = self.stream
            # issue 35046: merged two stream.writes into one.
            stream.write(msg + self.terminator)
            self.flush()

```

