### PR TITLE
WIP: Allow httphandler to have auth and other mediatype

### DIFF
--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -167,20 +167,20 @@ class PapermillIO:
 class HttpHandler:
     @classmethod
     def _get_auth_kwargs(cls):
-        username = os.environ.get('PAPERMILL_HTTP_AUTH_USERNAME', None)
-        password = os.environ.get('PAPERMILL_HTTP_AUTH_PASSWORD', None)
-        if username or password:
-            return {'auth': requests.auth.HTTPBasicAuth(username or '', password or '')}
+        """Gets the Authorization header from PAPERMILL_HTTP_AUTH_HEADER.
+        A valid value could be Basic dW5hbWU6cGFzc3dvcmQK"""
+        auth_header = os.environ.get('PAPERMILL_HTTP_AUTH_HEADER', None)
+        if auth_header:
+            return {'headers': {'Authorization': auth_header}}
         return {}
 
     @classmethod
     def _get_read_kwargs(cls):
-        kwargs = {}
-        kwargs['headers'] = {
-            'Accept': os.environ.get('PAPERMILL_HTTP_ACCEPT_TYPE', 'application/json')
+        kwargs = cls._get_auth_kwargs() or {'headers': {}}
+        kwargs['headers'] |= {
+            'Accept': os.environ.get('PAPERMILL_HTTP_ACCEPT_HEADER', 'application/json')
         }
-        return kwargs | cls._get_auth_kwargs()
-
+        return kwargs
 
     @classmethod
     def read(cls, path):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -168,7 +168,7 @@ class HttpHandler:
     @classmethod
     def _get_auth_kwargs(cls):
         """Gets the Authorization header from PAPERMILL_HTTP_AUTH_HEADER.
-        A valid value could be Basic dW5hbWU6cGFzc3dvcmQK"""
+        A valid example value Basic dW5hbWU6cGFzc3dvcmQK"""
         auth_header = os.environ.get('PAPERMILL_HTTP_AUTH_HEADER', None)
         if auth_header:
             return {'headers': {'Authorization': auth_header}}

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -184,7 +184,7 @@ class HttpHandler:
 
     @classmethod
     def read(cls, path):
-        return requests.get(path, **cls._get_read_kwargs())
+        return requests.get(path, **cls._get_read_kwargs()).text
 
     @classmethod
     def listdir(cls, path):

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -184,8 +184,7 @@ class HttpHandler:
 
     @classmethod
     def read(cls, path):
-        r =  requests.get(path, **cls._get_read_kwargs())
-        return r.text
+        return requests.get(path, **cls._get_read_kwargs())
 
     @classmethod
     def listdir(cls, path):

--- a/papermill/tests/test_iorw.py
+++ b/papermill/tests/test_iorw.py
@@ -327,45 +327,17 @@ class TestHttpHandler(unittest.TestCase):
         """
         path = 'http://example.com'
         text = 'request test response'
-        username = 'testusername'
-        password = 'testpassword'
-        auth_token = 'token'
+        auth = 'Basic dW5hbWU6cGFzc3dvcmQK'
 
-        with patch('papermill.iorw.requests.auth.HTTPBasicAuth') as mock_auth,\
-             patch.dict(os.environ, clear=True) as env,\
+        with patch.dict(os.environ, clear=True) as env,\
              patch('papermill.iorw.requests.get') as mock_get:
-            mock_auth.return_value = auth_token
-            env['PAPERMILL_HTTP_AUTH_USERNAME'] = username
-            env['PAPERMILL_HTTP_AUTH_PASSWORD'] = password
+            env['PAPERMILL_HTTP_AUTH_HEADER'] = auth
             mock_get.return_value = Mock(text=text)
 
             self.assertEqual(HttpHandler.read(path), text)
-            mock_auth.assert_called_once_with(username, password)
-            mock_get.assert_called_once_with(path, headers={'Accept': 'application/json'}, auth=auth_token)
+            mock_get.assert_called_once_with(path, headers={'Accept': 'application/json', 'Authorization': auth})
 
-    def test_read_with_token(self):
-        """
-        Tests that the `read` function performs a request to the giving path
-        with just a password as authentication and returns the response.
-        """
-        path = 'http://example.com'
-        text = 'request test response'
-        password = 'testpassword'
-        auth_token = 'token'
-
-        with patch('papermill.iorw.requests.auth.HTTPBasicAuth') as mock_auth,\
-             patch.dict(os.environ, clear=True) as env,\
-             patch('papermill.iorw.requests.get') as mock_get:
-            mock_auth.return_value = auth_token
-            env['PAPERMILL_HTTP_AUTH_PASSWORD'] = password
-            mock_get.return_value = Mock(text=text)
-
-            self.assertEqual(HttpHandler.read(path), text)
-            mock_auth.assert_called_once_with('', password)
-            mock_get.assert_called_once_with(path, headers={'Accept': 'application/json'}, auth=auth_token)
-
-
-    def test_read_with_accept_type(self):
+    def test_read_with_accept_header(self):
         """
         Tests that the `read` function performs a request to the giving path
         with an accept type from env variables and returns the response.
@@ -376,7 +348,7 @@ class TestHttpHandler(unittest.TestCase):
 
         with patch.dict(os.environ, clear=True) as env,\
              patch('papermill.iorw.requests.get') as mock_get:
-            env['PAPERMILL_HTTP_ACCEPT_TYPE'] = accept_type
+            env['PAPERMILL_HTTP_ACCEPT_HEADER'] = accept_type
             mock_get.return_value = Mock(text=text)
 
             self.assertEqual(HttpHandler.read(path), text)
@@ -394,25 +366,21 @@ class TestHttpHandler(unittest.TestCase):
             HttpHandler.write(buf, path)
             mock_put.assert_called_once_with(path, json=json.loads(buf))
 
-    def test_write_with_username(self):
+    def test_write_with_auth(self):
         """
         Tests that the `write` function performs a put request to the given
-        path with just a username as authentication from env variables.
+        path with authentication from env variables.
         """
         path = 'http://example.com'
         buf = '{"papermill": true}'
-        username = 'testusername'
-        auth_token = 'token'
+        auth = 'token'
 
-        with patch('papermill.iorw.requests.auth.HTTPBasicAuth') as mock_auth,\
-             patch.dict(os.environ, clear=True) as env,\
+        with patch.dict(os.environ, clear=True) as env,\
              patch('papermill.iorw.requests.put') as mock_put:
-            mock_auth.return_value = auth_token
-            env['PAPERMILL_HTTP_AUTH_USERNAME'] = username
+            env['PAPERMILL_HTTP_AUTH_HEADER'] = auth
 
             HttpHandler.write(buf, path)
-            mock_auth.assert_called_once_with(username, '')
-            mock_put.assert_called_once_with(path, json=json.loads(buf), auth=auth_token)
+            mock_put.assert_called_once_with(path, json=json.loads(buf), headers={'Authorization': auth})
 
     def test_write_failure(self):
         """


### PR DESCRIPTION
## HTTPHandler can now be given auth headers and a different accept media type than application/json

I wanted to use papermill to directly read my git repo (azure devops). Since the repo is not publicly available I needed a way to pass auth to papermill while not breaking any current implementations.

In line with other setups in papermill I added an env variable PAPERMILL_HTTP_AUTH_HEADER that will be passed to requests like this {"headers" {"Authorization": PAPERMILL_HTTP_AUTH_HEADER}}. As such it should work for  most auth setups. I only tested it for my use case (base64 encoded basic token).

I then also needed the reply to be "plain/text" instead of "application/json" so also added that option via an env var. PAPERMILL_HTTP_ACCEPT_HEADER

All relevant code is in iorw.py.

Wrote tests for all
