### PR TITLE
Provide ability to parse Python parameters included '=' character in value or comment

### DIFF
--- a/papermill/tests/notebooks/complex_parameters.ipynb
+++ b/papermill/tests/notebooks/complex_parameters.ipynb
@@ -21,9 +21,10 @@
     "# Interesting c variable\n",
     "c: \"NoneType\" = None\n",
     "# Not introspectable line\n",
-    "d = a == 3\n",
-    "# Broken name definition\n",
-    "= 2"
+    "d = \"a = 3\" # str value with '=' character\n",
+    "e = (a != 3 and 2 <= a <= 3) or a == 1 # bool value with logical operators\n",
+    "= 2\n",
+    "# Broken name definition\n"
    ]
   }
  ],

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -45,6 +45,13 @@ def click_context():
                     "help": "Nice list",
                 },
                 "c": {"name": "c", "inferred_type_name": "NoneType", "default": "None", "help": ""},
+                "d": {"name": "d", "inferred_type_name": "None", "default": "\"a = 3\"", "help": "str value with '=' character"},
+                "e": {
+                    "name": "e",
+                    "inferred_type_name": "None",
+                    "default": "(a != 3 and 2 <= a <= 3) or a == 1",
+                    "help": "bool value with logical operators"
+                },
             },
         ),
         (_get_fullpath("notimplemented_translator.ipynb"), {}),
@@ -87,6 +94,8 @@ def test_str_path():
                 "  a: float (default 2.25)         Variable a",
                 "  b: List[str] (default ['Hello','World'])\n                                  Nice list",
                 "  c: NoneType (default None)      ",
+                "  d: Unknown type (default \"a = 3\")\n                                  str value with '=' character",
+                "  e: Unknown type (default (a != 3 and 2 <= a <= 3) or a == 1)\n                                  bool value with logical operators",
             ],
         ),
         (

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -246,9 +246,6 @@ class PythonTranslator(Translator):
             if nequal > 0:
                 grouped_variable.append(flatten_accumulator(accumulator))
                 accumulator = []
-                if nequal > 1:
-                    logger.warning(f"Unable to parse line {iline + 1} '{line}'.")
-                    continue
 
             accumulator.append(line)
         grouped_variable.append(flatten_accumulator(accumulator))


### PR DESCRIPTION
## What does this PR do?

This OR provide ability to parse Python parameters included '=' character in value or comment.
For example
a = "somting = another" # str value with '=' character
b = (a != 3 and 2 <= a <= 3) or a == 1 # bool value calculated by logic expression

Fixes #721 
