### PR TITLE
Add function to suppress parameter output of sensitive information

### DIFF
--- a/docs/reference/papermill-cli.rst
+++ b/docs/reference/papermill-cli.rst
@@ -71,5 +71,11 @@ Command Line options
                                       failing execution (default: forever)
       --report-mode / --no-report-mode
                                       Flag for hiding input.
+      --obfuscate-sensitive-parameters / --no-obfuscate-sensitive-parameters
+                                      Flag for obfuscating sensitive parameters.
+      --sensitive-parameter-patterns TEXT...
+                                      List of patterns for obfuscating parameter
+                                      names in notebooks. If not provided, defaults
+                                      to papermill.utils.SENSITIVE_PARAMETER_PATTERNS.
       --version                       Flag for displaying the version.
       -h, --help                      Show this message and exit.

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -78,5 +78,11 @@ options:
 
       --report-mode / --no-report-mode
                                       Flag for hiding input.
+      --obfuscate-sensitive-parameters / --no-obfuscate-sensitive-parameters
+                                      Flag for obfuscating sensitive parameters.
+      --sensitive-parameter-patterns TEXT...
+                                      List of patterns for obfuscating parameter
+                                      names in notebooks. If not provided, defaults
+                                      to papermill.utils.SENSITIVE_PARAMETER_PATTERNS.
       --version                       Flag for displaying the version.
       -h, --help                      Show this message and exit.

--- a/papermill/engines.py
+++ b/papermill/engines.py
@@ -372,6 +372,14 @@ class Engine:
             nb_man.cleanup_pbar()
             nb_man.notebook_complete()
 
+        # Replace the source with the obfuscated content if it is in the metadata.
+        for cell in nb_man.nb.cells:
+            if cell.get('cell_type') != 'code':
+                continue
+            if 'papermill-obfuscated-source' not in cell.metadata:
+                continue
+            cell.source = cell.metadata['papermill-obfuscated-source']
+            del cell.metadata['papermill-obfuscated-source']
         return nb_man.nb
 
     @classmethod

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -8,7 +8,7 @@ from .inspection import _infer_parameters
 from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd, write_ipynb
 from .log import logger
 from .parameterize import add_builtin_parameters, parameterize_notebook, parameterize_path
-from .utils import chdir
+from .utils import chdir, obfuscate_parameters
 
 
 def execute_notebook(
@@ -27,6 +27,8 @@ def execute_notebook(
     start_timeout=60,
     report_mode=False,
     cwd=None,
+    obfuscate_sensitive_parameters=True,
+    sensitive_parameter_patterns=None,
     **engine_kwargs,
 ):
     """Executes a single notebook locally.
@@ -61,6 +63,11 @@ def execute_notebook(
         Flag for whether or not to hide input.
     cwd : str or Path, optional
         Working directory to use when executing the notebook
+    obfuscate_sensitive_parameters : bool, optional
+        Obfuscate sensitive parameters in the notebook, Defaults to True
+    sensitive_parameter_patterns : list, optional
+        List of parameter patterns to obfuscate in the notebook.
+        Defaults to `utils.SENSITIVE_PARAMETER_PATTERNS`
     **kwargs
         Arbitrary keyword arguments to pass to the notebook engine
 
@@ -102,6 +109,8 @@ def execute_notebook(
                 kernel_name=kernel_name,
                 language=language,
                 engine_name=engine_name,
+                obfuscate_sensitive_parameters=obfuscate_sensitive_parameters,
+                sensitive_parameter_patterns=sensitive_parameter_patterns,
             )
 
         nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode)

--- a/papermill/tests/test_parameterize.py
+++ b/papermill/tests/test_parameterize.py
@@ -81,6 +81,29 @@ class TestNotebookParametrizing(unittest.TestCase):
         first_line = cell_one['source'].split('\n')[0]
         self.assertEqual(first_line, '# This is a custom comment')
 
+    def test_sensitive_parameters_obfuscation(self):
+        test_nb = load_notebook_node(get_notebook_path("simple_execute.ipynb"))
+        test_nb = parameterize_notebook(test_nb, {'msg': 'Hello', 'password': 'secret'}, obfuscate_sensitive_parameters=True)
+
+        cell_one = test_nb.cells[1]
+        self.assertIn('password', cell_one['source'])
+        self.assertIn('secret', cell_one['source'])
+
+        self.assertIn('papermill-obfuscated-source', cell_one['metadata'])
+        obfuscated_output = cell_one['metadata']['papermill-obfuscated-source']
+        self.assertIn('password', obfuscated_output)
+        self.assertNotIn('secret', obfuscated_output)
+        self.assertIn('********', obfuscated_output)
+
+    def test_sensitive_parameters_obfuscation_disabled(self):
+        test_nb = load_notebook_node(get_notebook_path("simple_execute.ipynb"))
+        test_nb = parameterize_notebook(test_nb, {'msg': 'Hello', 'password': 'secret'}, obfuscate_sensitive_parameters=False)
+
+        cell_one = test_nb.cells[1]
+        self.assertIn('password', cell_one['source'])
+        self.assertIn('secret', cell_one['source'])
+
+        self.assertNotIn('papermill-obfuscated-source', cell_one['metadata'])
 
 class TestBuiltinParameters(unittest.TestCase):
     def test_add_builtin_parameters_keeps_provided_parameters(self):

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -13,6 +13,7 @@ from ..utils import (
     merge_kwargs,
     remove_args,
     retry,
+    obfuscate_parameter,
 )
 
 
@@ -58,3 +59,32 @@ def test_chdir():
             assert Path.cwd() == Path(temp_dir)
 
     assert Path.cwd() == old_cwd
+
+
+def test_obfuscate_parameter():
+    # *password*
+    assert obfuscate_parameter("password", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("sample_password", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("password_for_test", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("password", "") == ""
+
+    # *token*
+    assert obfuscate_parameter("token", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("sample_token", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("token_for_test", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("token", "") == ""
+
+    # *key*
+    assert obfuscate_parameter("key", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("sample_key", "string_to_be_obfuscated") == "********"
+    assert obfuscate_parameter("keyword", "string_not_to_be_obfuscated") == "string_not_to_be_obfuscated"
+    assert obfuscate_parameter("key", "") == ""
+
+
+def test_obfuscate_parameter_custom_pattern():
+    # *secret*
+    assert obfuscate_parameter("secret", "string_to_be_obfuscated", [".*secret"]) == "********"
+    assert obfuscate_parameter("sample_secret", "string_to_be_obfuscated", [".*secret"]) == "********"
+    assert obfuscate_parameter("secret_for_test", "string_to_be_obfuscated", [".*secret"]) == "********"
+    # If the custom pattern are set, the default pattern should not be applied
+    assert obfuscate_parameter("token", "string_to_be_obfuscated", [".*secret"]) == "string_to_be_obfuscated"

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import warnings
 from contextlib import contextmanager
 from functools import wraps
@@ -7,6 +8,23 @@ from functools import wraps
 from .exceptions import PapermillParameterOverwriteWarning
 
 logger = logging.getLogger('papermill.utils')
+
+
+SENSITIVE_PARAMETER_PATTERNS = [
+    r"(?i)pass(word|wd)",
+    r"(?i)pwd$",
+    # A short keyword that may match many keywords unintentionally
+    # is only targeted when placed at the end of the string.
+    r"(?i)pass$",
+    r"(?i)token",
+    r"(?i)secret",
+    r"(?i)authorization",
+    r"(?i)auth$",
+    r"(?i)key$",
+    r"(?i)access_key",
+    r"(?i)secret_key",
+    r"(?i)private_key",
+]
 
 
 def any_tagged_cell(nb, tag):
@@ -190,3 +208,61 @@ def chdir(path):
             yield
         finally:
             os.chdir(old_dir)
+
+def obfuscate_parameter(
+    name,
+    value,
+    name_patterns=None,
+    obfuscated_value="********",
+):
+    """Obfuscate parameter if it is sensitive.
+
+    Parameters
+    ----------
+    name : str
+        The name of the parameter
+    value : str
+        The value of the parameter
+    name_patterns : list, optional
+        List of patterns to obfuscate in the notebook. Defaults to `DEFAULT_OBFUSCATE_PATTERNS`
+    obfuscated_value : str, optional
+        The value to replace the sensitive parameter with. Defaults to "********"
+
+    Returns
+    -------
+    str
+        The obfuscated value if the parameter is sensitive, otherwise the original value
+    """
+    if name_patterns is None:
+        name_patterns = SENSITIVE_PARAMETER_PATTERNS
+
+    if len(name_patterns) == 0:
+        raise ValueError("No name patterns provided to obfuscate")
+    if not value:
+        # Return empty string if value is empty to show that the parameter is empty
+        return value
+    if any(re.search(pattern, name) for pattern in name_patterns):
+        return obfuscated_value
+    return value
+
+def obfuscate_parameters(params, name_patterns=None, obfuscated_value="********"):
+    """Obfuscate parameters if they are sensitive.
+
+    Parameters
+    ----------
+    params : dict
+        The parameters to obfuscate
+    name_patterns : list, optional
+        List of patterns to obfuscate in the notebook. Defaults to `DEFAULT_OBFUSCATE_PATTERNS`
+    obfuscated_value : str, optional
+        The value to replace the sensitive parameter with. Defaults to "********"
+
+    Returns
+    -------
+    dict
+        The obfuscated parameters
+    """
+    return {
+        name: obfuscate_parameter(name, value, name_patterns, obfuscated_value)
+        for name, value in params.items()
+    }


### PR DESCRIPTION
## What does this PR do?

Fixes #706 - I believe it would be good if secret information contained in the parameters was masked with a string like `******`.

By applying this pull request, papermill will obfuscate the value stored in the injected-parameters cell and notebook metadata for parameters that contain strings like `token` and `secret`. I have not implemented obfuscation of these parameters in the output cell because it is not simple to do so and I assume it would have a significant impact.
For security reasons, I considered that it would be better to enable obfuscation by default. So I added the option `--no-obfuscate-sensitive-parameters` to turn it off.

In addition, the parameters that should be marked as sensitive are listed in `papermill.utils.SENSITIVE_PARAMETER_PATTERNS`. The `--sensitive-parameter-patterns` option can be used to customize the list.
