### PR TITLE
Unskip tests that were previously failing

### DIFF
--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -174,7 +174,6 @@ class TestBrokenNotebook2(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    @unittest.skip("FIX: Test is broken")
     def test(self):
         path = get_notebook_path('broken2.ipynb')
         result_path = os.path.join(self.test_dir, 'broken2.ipynb')
@@ -439,7 +438,6 @@ class TestOutputFormatting(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    @unittest.skip("FIX: Test is broken")
     def test_output_formatting(self):
         notebook_name = 'sysexit1.ipynb'
         result_path = os.path.join(self.test_dir, f'output_{notebook_name}')


### PR DESCRIPTION
Fixes #831 

Tested locally with 3.13 which was failing earlier in the day.