### PR TITLE
Fallback to default kernel if none specified.

### DIFF
--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -40,17 +40,9 @@ def nb_kernel_name(nb, name=None):
     Returns
     -------
     str
-        The name of the kernel
-
-    Raises
-    ------
-    ValueError
-        If no kernel name is found or provided
+        The name of the kernel or an empty string if none is found
     """
-    name = name or nb.metadata.get('kernelspec', {}).get('name')
-    if not name:
-        raise ValueError("No kernel name found in notebook and no override provided.")
-    return name
+    return name or nb.metadata.get('kernelspec', {}).get('name', '')
 
 
 def nb_language(nb, language=None):


### PR DESCRIPTION
We are being overly aggressive by raising an error if a kernel cannot be detected in a notebook. In an environment with only one kernel installed, the notebook executes just fine without errors, and we should not prematurely raise an error.

Fixes #338