### PR TITLE
Use SPDX license expression, drop deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "papermill"
 description = "Parameterize and run Jupyter and nteract Notebooks"
 readme = "README.md"
 keywords = [ "jupyter", "mapreduce", "notebook", "nteract", "pipeline" ]
-license = { text = "BSD" }
+license = "BSD-3-Clause"
 authors = [
   { name = "nteract contributors", email = "nteract@googlegroups.com" },
 ]
@@ -17,7 +17,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Intended Audience :: System Administrators",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Setuptools now warns about the deprecated `project.license` table format and the `License ::` classifier. This switches to the modern SPDX license expression (`"BSD-3-Clause"`) and drops the deprecated classifier.

Cleans up the deprecation warnings from the 2.7.0 build.