### PR TITLE
fix: bump nbformat minimum version to 5.10.4 for numpy 2.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "click",
   "entrypoints",
   "nbclient>=0.2",
-  "nbformat>=5.2",
+  "nbformat>=5.10.4",
   "pyyaml",
   "requests",
   "tenacity>=5.0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click
 pyyaml
-nbformat >= 5.2.0
+nbformat >= 5.10.4
 nbclient >= 0.2.0
 tqdm >= 4.32.2
 requests


### PR DESCRIPTION
Fixes #800

## Summary

Fix for #800: 该 Issue 报告了 papermill 在 numpy v2.0.0 环境下运行时出现 `AttributeError: _ARRAY_API not found` 错误。这是由于旧版本的 `nbformat` 依赖了 numpy v2 中已移除或更改的内部 API。

## Changes

```
pyproject.toml   | 2 +-
 requirements.txt | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```
