### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
     env:
-      USING_COVERAGE: '3.10,3.11,3.12,3.13'
+      USING_COVERAGE: '3.10,3.11,3.12,3.13,3.14'
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: "actions/checkout@v6"

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -159,7 +159,9 @@ class TestBrokenNotebook1(unittest.TestCase):
         self.assertRegex(nb.cells[5].source, '<span id="papermill-error-cell" .*</span>')
         self.assertEqual(nb.cells[5].metadata["tags"], ["papermill-error-cell-tag"])
         self.assertEqual(nb.cells[6].execution_count, 2)
-        self.assertEqual(nb.cells[6].outputs[0].output_type, 'error')
+        # Python 3.14+ emits a stderr stream before the error output for assertion errors
+        output_types = [o.output_type for o in nb.cells[6].outputs]
+        self.assertIn('error', output_types)
 
         self.assertEqual(nb.cells[7].execution_count, None)
 
@@ -187,8 +189,10 @@ class TestBrokenNotebook2(unittest.TestCase):
         self.assertEqual(nb.cells[2].cell_type, "markdown")
         self.assertRegex(nb.cells[2].source, '<span id="papermill-error-cell" .*</span>')
         self.assertEqual(nb.cells[3].execution_count, 2)
-        self.assertEqual(nb.cells[3].outputs[0].output_type, 'display_data')
-        self.assertEqual(nb.cells[3].outputs[1].output_type, 'error')
+        # Python 3.14+ may insert a stderr stream between display_data and error outputs
+        output_types = [o.output_type for o in nb.cells[3].outputs]
+        self.assertIn('display_data', output_types)
+        self.assertIn('error', output_types)
 
         self.assertEqual(nb.cells[4].execution_count, None)
 
@@ -279,9 +283,12 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[0].cell_type, "code")
         self.assertEqual(nb.cells[0].execution_count, 1)
         self.assertEqual(nb.cells[1].execution_count, 2)
-        self.assertEqual(nb.cells[1].outputs[0].output_type, 'error')
-        self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
-        self.assertEqual(nb.cells[1].outputs[0].evalue, '')
+        # Python 3.14+ may emit a stderr stream before the error output
+        output_types = [o.output_type for o in nb.cells[1].outputs]
+        self.assertIn('error', output_types)
+        error_output = next(o for o in nb.cells[1].outputs if o.output_type == 'error')
+        self.assertEqual(error_output.ename, 'SystemExit')
+        self.assertEqual(error_output.evalue, '')
         self.assertEqual(nb.cells[2].execution_count, None)
 
     def test_sys_exit0(self):
@@ -292,9 +299,12 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[0].cell_type, "code")
         self.assertEqual(nb.cells[0].execution_count, 1)
         self.assertEqual(nb.cells[1].execution_count, 2)
-        self.assertEqual(nb.cells[1].outputs[0].output_type, 'error')
-        self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
-        self.assertEqual(nb.cells[1].outputs[0].evalue, '0')
+        # Python 3.14+ may emit a stderr stream before the error output
+        output_types = [o.output_type for o in nb.cells[1].outputs]
+        self.assertIn('error', output_types)
+        error_output = next(o for o in nb.cells[1].outputs if o.output_type == 'error')
+        self.assertEqual(error_output.ename, 'SystemExit')
+        self.assertEqual(error_output.evalue, '0')
         self.assertEqual(nb.cells[2].execution_count, None)
 
     def test_sys_exit1(self):
@@ -310,7 +320,9 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[2].cell_type, "markdown")
         self.assertRegex(nb.cells[2].source, '<span id="papermill-error-cell" .*</span>')
         self.assertEqual(nb.cells[3].execution_count, 2)
-        self.assertEqual(nb.cells[3].outputs[0].output_type, 'error')
+        # Python 3.14+ may emit a stderr stream before the error output
+        output_types = [o.output_type for o in nb.cells[3].outputs]
+        self.assertIn('error', output_types)
 
         self.assertEqual(nb.cells[4].execution_count, None)
 
@@ -322,9 +334,12 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[0].cell_type, "code")
         self.assertEqual(nb.cells[0].execution_count, 1)
         self.assertEqual(nb.cells[1].execution_count, 2)
-        self.assertEqual(nb.cells[1].outputs[0].output_type, 'error')
-        self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
-        self.assertEqual(nb.cells[1].outputs[0].evalue, '')
+        # Python 3.14+ may emit a stderr stream before the error output
+        output_types = [o.output_type for o in nb.cells[1].outputs]
+        self.assertIn('error', output_types)
+        error_output = next(o for o in nb.cells[1].outputs if o.output_type == 'error')
+        self.assertEqual(error_output.ename, 'SystemExit')
+        self.assertEqual(error_output.evalue, '')
         self.assertEqual(nb.cells[2].execution_count, None)
 
     def test_line_magic_error(self):
@@ -456,6 +471,8 @@ class TestOutputFormatting(unittest.TestCase):
         self.assertEqual(nb.cells[2].cell_type, "markdown")
         self.assertRegex(nb.cells[2].source, '<span id="papermill-error-cell" .*</span>')
         self.assertEqual(nb.cells[3].execution_count, 2)
-        self.assertEqual(nb.cells[3].outputs[0].output_type, 'error')
+        # Python 3.14+ may emit a stderr stream before the error output
+        output_types = [o.output_type for o in nb.cells[3].outputs]
+        self.assertIn('error', output_types)
 
         self.assertEqual(nb.cells[4].execution_count, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ omit = [
 legacy_tox_ini = """
 [tox]
 skipsdist = true
-envlist = py{310,311,312,313}, dist, manifest, docs, binder
+envlist = py{310,311,312,313,314}, dist, manifest, docs, binder
 
 [gh-actions]
 python =
@@ -233,6 +233,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313, docs, dist
+    3.14: py314
 
 # Manifest
 [testenv:manifest]
@@ -280,6 +281,7 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    py314: python3.14
     manifest: python3.13
     dist: python3.13
     docs: python3.13


### PR DESCRIPTION
## Summary

- Add Python 3.14 to CI matrix, tox envlist, gh-actions mapping, basepython, and USING_COVERAGE
- Fix test assertions in `TestBrokenNotebook1`, `TestBrokenNotebook2`, `TestSysExit`, and `TestOutputFormatting` to accommodate Python 3.14's changed traceback rendering (may emit a stderr stream before the error output)

Note: Python 3.14 trove classifier is not included because `pyproject-fmt` does not yet recognize it. It can be added once `pyproject-fmt` is updated.

Closes #841

## Test plan

- [x] CI passes on Python 3.10–3.14
- [x] All broken notebook and sys exit tests pass on Python 3.14
- [x] No regressions on existing Python versions