### PR TITLE
Make `kernel_name` override update notebook `kernelspec` metadata

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -86,7 +86,7 @@ def print_papermill_version(ctx, param, value):
 @click.option(
     '--kernel',
     '-k',
-    help='Name of kernel to run. Ignores kernel name in the notebook document metadata.',
+    help='Name of kernel to run. Overrides kernel name in the notebook document metadata.',
 )
 @click.option(
     '--language',

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -11,6 +11,17 @@ from .parameterize import add_builtin_parameters, parameterize_notebook, paramet
 from .utils import chdir
 
 
+def _override_kernel_name_in_metadata(nb, kernel_name):
+    if not kernel_name:
+        return nb
+
+    kernelspec = nb.metadata.get('kernelspec', {})
+    kernelspec['name'] = kernel_name
+    kernelspec['display_name'] = kernel_name
+    nb.metadata['kernelspec'] = kernelspec
+    return nb
+
+
 def execute_notebook(
     input_path,
     output_path,
@@ -104,7 +115,7 @@ def execute_notebook(
                 engine_name=engine_name,
             )
 
-        nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode)
+        nb = prepare_notebook_metadata(nb, input_path, output_path, report_mode, kernel_name=kernel_name)
         # clear out any existing error markers from previous papermill runs
         nb = remove_error_markers(nb)
 
@@ -136,7 +147,7 @@ def execute_notebook(
         return nb
 
 
-def prepare_notebook_metadata(nb, input_path, output_path, report_mode=False):
+def prepare_notebook_metadata(nb, input_path, output_path, report_mode=False, kernel_name=None):
     """Prepare metadata associated with a notebook and its cells
 
     Parameters
@@ -149,6 +160,8 @@ def prepare_notebook_metadata(nb, input_path, output_path, report_mode=False):
        Path to write executed notebook
     report_mode : bool, optional
        Flag to set report mode
+    kernel_name : str, optional
+       Name of kernel to persist in notebook metadata
     """
     # Hide input if report-mode is set to True.
     if report_mode:
@@ -156,6 +169,8 @@ def prepare_notebook_metadata(nb, input_path, output_path, report_mode=False):
             if cell.cell_type == 'code':
                 cell.metadata['jupyter'] = cell.get('jupyter', {})
                 cell.metadata['jupyter']['source_hidden'] = True
+
+    nb = _override_kernel_name_in_metadata(nb, kernel_name)
 
     # Record specified environment variable values.
     nb.metadata.papermill['input_path'] = input_path

--- a/papermill/tests/__init__.py
+++ b/papermill/tests/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 kernel_name = 'python3'
+override_kernel_name = 'papermill-kernel-override'
 
 
 def get_notebook_path(*args):

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 
 from .. import cli
 from ..cli import _is_float, _is_int, _resolve_type, papermill
-from . import get_notebook_path, kernel_name
+from . import get_notebook_path, kernel_name, override_kernel_name
 
 
 @pytest.mark.parametrize(
@@ -70,6 +70,20 @@ def test_is_float(value, expected):
 )
 def test_is_int(value, expected):
     assert (_is_int(value)) == expected
+
+
+def test_kernel_override_updates_output_metadata():
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_path = os.path.join(tmp_dir, f"{uuid.uuid4().hex}.ipynb")
+        result = runner.invoke(
+            papermill,
+            [get_notebook_path('blank-vscode.ipynb'), output_path, '--prepare-only', '-k', override_kernel_name],
+        )
+        assert result.exit_code == 0
+        output_nb = nbformat.read(output_path, as_version=4)
+        assert output_nb.metadata.kernelspec.name == override_kernel_name
+        assert output_nb.metadata.kernelspec.display_name == override_kernel_name
 
 
 class TestCLI(unittest.TestCase):


### PR DESCRIPTION
## Summary

The current execution flow appears to pass `kernel_name` to the execution engine, but does not reliably persist that override into the output notebook metadata. As a result, notebook consumers (e.g., JupyterHub UI) still show the original `kernelspec.display_name` and/or `kernelspec.name`. This file should be updated so that when `kernel_name` is provided, the in-memory notebook object has its metadata rewritten before output is saved.

## Files changed

- `papermill/execute.py` (modified)
- `papermill/cli.py` (modified)
- `papermill/tests/__init__.py` (modified)
- `papermill/tests/test_cli.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>


Closes #856