### PR TITLE
Add strict unknown-parameter validation mode to notebook execution

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -84,6 +84,11 @@ def print_papermill_version(ctx, param, value):
     help="Flag for outputting the notebook without execution, but with parameters applied.",
 )
 @click.option(
+    '--raise-on-unknown-parameters/--no-raise-on-unknown-parameters',
+    default=False,
+    help='Flag for whether or not to raise when unknown parameters are passed.',
+)
+@click.option(
     '--kernel',
     '-k',
     help='Name of kernel to run. Ignores kernel name in the notebook document metadata.',
@@ -154,6 +159,7 @@ def papermill(
     request_save_on_cell_execute,
     autosave_cell_every,
     prepare_only,
+    raise_on_unknown_parameters,
     kernel,
     language,
     cwd,
@@ -240,6 +246,7 @@ def papermill(
             request_save_on_cell_execute=request_save_on_cell_execute,
             autosave_cell_every=autosave_cell_every,
             prepare_only=prepare_only,
+            raise_on_unknown_parameters=raise_on_unknown_parameters,
             kernel_name=kernel,
             language=language,
             progress_bar=progress_bar,

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import nbformat
 
 from .engines import papermill_engines
-from .exceptions import PapermillExecutionError
+from .exceptions import PapermillException, PapermillExecutionError
 from .inspection import _infer_parameters
 from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd, write_ipynb
 from .log import logger
@@ -15,6 +15,7 @@ def execute_notebook(
     input_path,
     output_path,
     parameters=None,
+    raise_on_unknown_parameters=False,
     engine_name=None,
     request_save_on_cell_execute=True,
     prepare_only=False,
@@ -39,6 +40,8 @@ def execute_notebook(
         Path to save executed notebook. If None, no file will be saved
     parameters : dict, optional
         Arbitrary keyword arguments to pass to the notebook parameters
+    raise_on_unknown_parameters : bool, optional
+        Flag for whether or not to raise when parameters are passed that are not declared in the notebook
     engine_name : str, optional
         Name of execution engine to use
     request_save_on_cell_execute : bool, optional
@@ -92,8 +95,12 @@ def execute_notebook(
         if parameters:
             parameter_predefined = _infer_parameters(nb, name=kernel_name, language=language)
             parameter_predefined = {p.name for p in parameter_predefined}
-            for p in parameters:
-                if p not in parameter_predefined:
+            unknown_parameters = [p for p in parameters if p not in parameter_predefined]
+            if unknown_parameters:
+                if raise_on_unknown_parameters:
+                    unknown_parameters_message = ", ".join(str(p) for p in sorted(unknown_parameters, key=str))
+                    raise PapermillException(f"Passed unknown parameters: {unknown_parameters_message}")
+                for p in unknown_parameters:
                     logger.warning(f"Passed unknown parameter: {p}")
             nb = parameterize_notebook(
                 nb,

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -81,6 +81,7 @@ class TestCLI(unittest.TestCase):
         request_save_on_cell_execute=True,
         autosave_cell_every=30,
         prepare_only=False,
+        raise_on_unknown_parameters=False,
         kernel_name=None,
         language=None,
         log_output=False,
@@ -111,6 +112,11 @@ class TestCLI(unittest.TestCase):
     def test_parameters(self, execute_patch):
         self.runner.invoke(papermill, self.default_args + ['-p', 'foo', 'bar', '--parameters', 'baz', '42'])
         execute_patch.assert_called_with(**self.augment_execute_kwargs(parameters={'foo': 'bar', 'baz': 42}))
+
+    @patch(f"{cli.__name__}.execute_notebook")
+    def test_raise_on_unknown_parameters(self, execute_patch):
+        self.runner.invoke(papermill, self.default_args + ['--raise-on-unknown-parameters'])
+        execute_patch.assert_called_with(**self.augment_execute_kwargs(raise_on_unknown_parameters=True))
 
     @patch(f"{cli.__name__}.execute_notebook")
     def test_parameters_raw(self, execute_patch):


### PR DESCRIPTION
## Summary

Extend `execute_notebook(...)` with a new boolean argument (default `False`) that controls behavior when user-supplied parameters are not declared in the notebook’s `parameters` cell. Today papermill warns for unknown keys; this change should preserve that default but allow strict failure when requested.

## Files changed

- `papermill/execute.py` (modified)
- `papermill/cli.py` (modified)
- `papermill/tests/test_cli.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>


Closes #818