### PR TITLE
Expand `execute_notebook` docstring to fully document optional parameters

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -76,7 +76,7 @@ def print_papermill_version(ctx, param, value):
     '--autosave-cell-every',
     default=30,
     type=int,
-    help='How often in seconds to autosave the notebook during long cell executions (0 to disable)',
+    help='How often in seconds to autosave the notebook during long cell executions (0 to disable). Forwarded to the execution engine.',
 )
 @click.option(
     '--prepare-only/--prepare-execute',

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -43,8 +43,6 @@ def execute_notebook(
         Name of execution engine to use
     request_save_on_cell_execute : bool, optional
         Request save notebook after each cell execution
-    autosave_cell_every : int, optional
-        How often in seconds to save in the middle of long cell executions
     prepare_only : bool, optional
         Flag to determine if execution should occur or not
     kernel_name : str, optional
@@ -55,14 +53,21 @@ def execute_notebook(
         Flag for whether or not to show the progress bar.
     log_output : bool, optional
         Flag for whether or not to write notebook output to the configured logger
+    stdout_file : str or file-like, optional
+        File path or buffer used to write notebook stdout
+    stderr_file : str or file-like, optional
+        File path or buffer used to write notebook stderr
     start_timeout : int, optional
         Duration in seconds to wait for kernel start-up
     report_mode : bool, optional
         Flag for whether or not to hide input.
     cwd : str or Path, optional
         Working directory to use when executing the notebook
-    **kwargs
-        Arbitrary keyword arguments to pass to the notebook engine
+    **engine_kwargs
+        Arbitrary keyword arguments forwarded to the selected execution engine
+        (and underlying nbclient execution). Common options include
+        ``execution_timeout`` and ``autosave_cell_every``. Supported options
+        may vary by engine
 
     Returns
     -------


### PR DESCRIPTION
## Summary

The current `execute_notebook` docstring is incomplete/inconsistent with actual usage. It mentions `autosave_cell_every` even though it is not an explicit function argument, and it does not document `stdout_file`, `stderr_file`, or how `execution_timeout` and other engine options are passed through `**engine_kwargs`. Since this function is the core Python API entry point, its docstring should be the source of truth and align with both CLI behavior and internal engine forwarding.

## Files changed

- `papermill/execute.py` (modified)
- `papermill/cli.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>


Closes #808