### PR TITLE
Accept dotted (module-qualified) type names in parameter annotations

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -83,6 +83,10 @@ def test_translate_comment_python(test_input, expected):
             [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")],
         ),
         (
+            "a: datetime.date = '2024-01-01' # Nice variable a",
+            [Parameter("a", "datetime.date", "'2024-01-01'", "Nice variable a")],
+        ),
+        (
             "a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a",  # noqa
             [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")],
         ),

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -143,7 +143,7 @@ class Translator:
 class PythonTranslator(Translator):
     # Pattern to capture parameters within cell input
     PARAMETER_PATTERN = re.compile(
-        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
+        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s\.]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
     )
 
     @classmethod


### PR DESCRIPTION
## Summary

The Python parameter inference logic currently misses annotated parameters when the annotation is package-scoped (for example `datetime.date`, `datetime.datetime`, `datetime.time`). This causes `--help-notebook` to skip otherwise valid parameters declared with PEP-526 style annotations. The root cause is an overly restrictive annotation-matching regex that accepts only a single identifier token for the type.

## Files changed

- `papermill/translators.py` (modified)
- `papermill/tests/test_translators.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>


Closes #807