### PR TITLE
Extend `PapermillExecutionError` to carry the executed output notebook object

### DIFF
--- a/papermill/exceptions.py
+++ b/papermill/exceptions.py
@@ -20,7 +20,7 @@ class PapermillMissingParameterException(PapermillException):
 class PapermillExecutionError(PapermillException):
     """Raised when an exception is encountered in a notebook."""
 
-    def __init__(self, cell_index, exec_count, source, ename, evalue, traceback):
+    def __init__(self, cell_index, exec_count, source, ename, evalue, traceback, output_notebook=None):
         args = cell_index, exec_count, source, ename, evalue, traceback
         self.cell_index = cell_index
         self.exec_count = exec_count
@@ -28,6 +28,7 @@ class PapermillExecutionError(PapermillException):
         self.ename = ename
         self.evalue = evalue
         self.traceback = traceback
+        self.output_notebook = output_notebook
 
         super().__init__(*args)
 

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -211,6 +211,7 @@ def raise_for_execution_errors(nb, output_path):
                         ename=output.ename,
                         evalue=output.evalue,
                         traceback=output.traceback,
+                        output_notebook=nb,
                     )
                     break
 

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -31,6 +31,13 @@ class TestNotebookHelpers(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
+    def test_execution_error_includes_output_notebook(self):
+        notebook_name = 'broken.ipynb'
+        nb_test_executed_fname = os.path.join(self.test_dir, f'output_{notebook_name}')
+        with self.assertRaises(PapermillExecutionError) as err:
+            execute_notebook(get_notebook_path(notebook_name), nb_test_executed_fname)
+        self.assertIsInstance(err.exception.output_notebook, nbformat.NotebookNode)
+
     @patch(f"{engines.__name__}.PapermillNotebookClient")
     def test_start_timeout(self, preproc_mock):
         execute_notebook(self.notebook_path, self.nb_test_executed_fname, start_timeout=123)


### PR DESCRIPTION
## Summary

`PapermillExecutionError` currently exposes execution metadata (cell index, source, traceback details) but not the executed notebook object itself. This issue’s core requirement is to make the in-memory output notebook available directly from the exception so callers can inspect outputs (e.g., scrapbook data) without round-tripping through storage.

## Files changed

- `papermill/exceptions.py` (modified)
- `papermill/execute.py` (modified)
- `papermill/tests/test_execute.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>


Closes #795