### PR TITLE
Extend parameter file loader to parse TOML in addition to YAML

### DIFF
--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -42,7 +42,7 @@ def print_papermill_version(ctx, param, value):
 )
 @click.option('--parameters', '-p', nargs=2, multiple=True, help='Parameters to pass to the parameters cell.')
 @click.option('--parameters_raw', '-r', nargs=2, multiple=True, help='Parameters to be read as raw string.')
-@click.option('--parameters_file', '-f', multiple=True, help='Path to YAML file containing parameters.')
+@click.option('--parameters_file', '-f', multiple=True, help='Path to YAML or TOML file containing parameters.')
 @click.option('--parameters_yaml', '-y', multiple=True, help='YAML string to be used as parameters.')
 @click.option('--parameters_base64', '-b', multiple=True, help='Base64 encoded YAML string as parameters.')
 @click.option(

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -5,6 +5,14 @@ import sys
 import warnings
 from contextlib import contextmanager
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
+
 import entrypoints
 import nbformat
 import requests


### PR DESCRIPTION
## Summary

The current `read_yaml_file` path is YAML-specific and is used by CLI `--parameters_file`. To support issue #719 cleanly, this loader should accept TOML files (primarily `.toml`) while preserving existing YAML behavior and backward compatibility for current callers.

## Files changed

- `papermill/iorw.py` (modified)
- `papermill/cli.py` (modified)

## Testing

- Not run in this environment.

## What does this PR do?



Fixes #\<issue_number>
