### PR TITLE
Add citation guidance to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,17 @@ This library currently supports python 3.10+ versions. As minor python
 versions are officially sunset by the python org papermill will similarly
 drop support in the future.
 
+Citing Papermill
+----------------
+
+If Papermill supports your research, please cite it as software in your
+publication and include the version that you used. For example:
+
+.. code-block:: text
+
+   nteract contributors. Papermill: parameterize and execute Jupyter notebooks.
+   Version X.Y.Z. https://github.com/nteract/papermill
+
 Documentation
 -------------
 


### PR DESCRIPTION
## Summary

- add a short citation section to the documentation home page
- give academic users a factual software citation template with the project URL and version placeholder

Closes #881.

## Validation

- `.venv/bin/sphinx-build -d .tox/docs_doctree docs .tox/docs_out --color -W -bhtml`
- `git diff --check`

I also tried `.venv/bin/tox -e docs`, but tox skipped locally because this repository maps the docs environment to `python3.13`, which is not installed on this machine.
