### PR TITLE
Translate tuple parameters through the list translator

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -19,6 +19,7 @@ from ..models import Parameter
         ({"foo": ["bar"]}, '{"foo": ["bar"]}'),
         ({"foo": {"bar": "baz"}}, '{"foo": {"bar": "baz"}}'),
         ({"foo": {"bar": '"baz"'}}, '{"foo": {"bar": "\\"baz\\""}}'),
+        ({"foo": (0.05, "<")}, '{"foo": [0.05, "<"]}'),
         (["foo"], '["foo"]'),
         (["foo", '"bar"'], '["foo", "\\"bar\\""]'),
         ([{"foo": "bar"}], '[{"foo": "bar"}]'),

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -96,7 +96,7 @@ class Translator:
             return cls.translate_float(val)
         elif isinstance(val, dict):
             return cls.translate_dict(val)
-        elif isinstance(val, list):
+        elif isinstance(val, (list, tuple)):
             return cls.translate_list(val)
         # Use this generic translation as a last resort
         return cls.translate_escaped_str(val)


### PR DESCRIPTION
## What does this PR do?

Tuple parameter values currently fall through to the generic escaped-string translation path. This changes their type in generated parameter cells, including when a tuple is nested inside a dictionary.

This change routes tuples through the existing list translator. It preserves the tuple's values while producing the JSON-compatible list representation recommended in the issue discussion. A regression case covers a nested tuple matching the reported configuration shape.

Fixes #784

## Verification

- `pytest papermill/tests/test_translators.py -k test_translate_type_python -q`
- `pytest papermill/tests/test_translators.py -q`
- `pytest -q`
- `pre-commit run --files papermill/translators.py papermill/tests/test_translators.py`

All 548 tests and the changed-file pre-commit hooks passed locally.