### PR TITLE
Recognize PEP 604 parameter annotations

### DIFF
--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -68,6 +68,8 @@ def test_translate_comment_python(test_input, expected):
     [
         ("a = 2", [Parameter("a", "None", "2", "")]),
         ("a: int = 2", [Parameter("a", "int", "2", "")]),
+        ("a: None | str = None", [Parameter("a", "None | str", "None", "")]),
+        ("a: list[str] | None = None", [Parameter("a", "list[str] | None", "None", "")]),
         ("a = 2 # type:int", [Parameter("a", "int", "2", "")]),
         ("a = False # Nice variable a", [Parameter("a", "None", "False", "Nice variable a")]),
         (

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -143,7 +143,7 @@ class Translator:
 class PythonTranslator(Translator):
     # Pattern to capture parameters within cell input
     PARAMETER_PATTERN = re.compile(
-        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
+        r"^(?P<target>\w[\w_]*)\s*(:\s*[\"']?(?P<annotation>\w[\w_\[\],\s|]*)[\"']?\s*)?=\s*(?P<value>.*?)(\s*#\s*(type:\s*(?P<type_comment>[^\s]*)\s*)?(?P<help>.*))?$"
     )
 
     @classmethod


### PR DESCRIPTION
## What does this PR do?

`PythonTranslator.inspect` currently skips parameters annotated with PEP 604
union syntax because its annotation pattern does not accept `|`. As a result,
a valid parameter such as `value: str | None = None` is omitted from notebook
inspection and is reported as unknown when overridden.

This change accepts the union operator in Python annotations and adds
regression cases for both `None | str` and `list[str] | None`.

Fixes #806

## Testing

- `python -m pytest papermill/tests/test_translators.py::test_inspect_python -q`
- `python -m pytest papermill/tests/test_translators.py -q`
- `python -m pytest -q`
- `pre-commit run --files papermill/translators.py papermill/tests/test_translators.py`
- `check-manifest`
