### PR TITLE
docs: fix typo in Sphinx configuration comment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ release = papermill.__version__
 # for a list of supported languages.
 #
 # This is also used if you do content translation via gettext catalogs.
-# Usually you set "language" from the command line foexitr these cases.
+# Usually you set "language" from the command line for these cases.
 language = 'python'
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #\<issue_number>

## Summary

This PR fixes a small typo in the Sphinx documentation configuration comment.

### Changes
- Replaced `foexitr` with `for` in the comment describing the `language` configuration.

This is a documentation-only change and does not affect functionality.
