### PR TITLE
Fix parameter inspection for defaults containing equals

### DIFF
--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -110,6 +110,29 @@ class TestNotebookHelpers(unittest.TestCase):
         )
         self.assertEqual(test_nb.metadata.papermill.parameters, {'foo': r'\\"bar\\"'})
 
+    def test_parameter_default_string_containing_equals_is_known(self):
+        notebook_path = os.path.join(self.test_dir, 'string_equals.ipynb')
+        nb = nbformat.v4.new_notebook(
+            cells=[
+                nbformat.v4.new_code_cell(
+                    source='msg = "a=b"',
+                    metadata={"tags": ["parameters"]},
+                )
+            ],
+            metadata={
+                "kernelspec": {"name": kernel_name, "language": "python", "display_name": "Python 3"},
+                "language_info": {"name": "python"},
+            },
+        )
+        nbformat.write(nb, notebook_path)
+
+        with patch.object(logger, 'warning') as warning_mock:
+            execute_notebook(notebook_path, self.nb_test_executed_fname, {'msg': 'Hello'}, prepare_only=True)
+
+        warning_mock.assert_not_called()
+        test_nb = load_notebook_node(self.nb_test_executed_fname)
+        self.assertEqual(test_nb.metadata.papermill.parameters, {'msg': 'Hello'})
+
     def test_prepare_only(self):
         for example in ['broken1.ipynb', 'keyboard_interrupt.ipynb']:
             path = get_notebook_path(example)

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -78,6 +78,12 @@ def test_translate_comment_python(test_input, expected):
             "a = 'this is a string' # type: int Nice variable a",
             [Parameter("a", "int", "'this is a string'", "Nice variable a")],
         ),
+        ('a = "this=that"', [Parameter("a", "None", '"this=that"', "")]),
+        ('a = dict(foo="bar=baz")', [Parameter("a", "None", 'dict(foo="bar=baz")', "")]),
+        (
+            'a = dict(\n    foo="bar=baz",\n    bar=1,\n)',
+            [Parameter("a", "None", 'dict(foo="bar=baz",bar=1,)', "")],
+        ),
         (
             "a: List[str] = ['this', 'is', 'a', 'string', 'list'] # Nice variable a",
             [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")],

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -1,7 +1,9 @@
+import io
 import logging
 import math
 import re
 import shlex
+import tokenize
 
 from .exceptions import PapermillException
 from .models import Parameter
@@ -191,6 +193,35 @@ class PythonTranslator(Translator):
         return content
 
     @classmethod
+    def _count_top_level_assignments(cls, line):
+        assignment_count = 0
+        equals_count = 0
+        bracket_delta = 0
+        bracket_depth = 0
+
+        try:
+            tokens = tokenize.generate_tokens(io.StringIO(f"{line}\n").readline)
+            for token in tokens:
+                if token.type != tokenize.OP:
+                    continue
+
+                if token.string in "([{":
+                    bracket_depth += 1
+                    bracket_delta += 1
+                elif token.string in ")]}":
+                    bracket_depth -= 1
+                    bracket_delta -= 1
+                elif token.string == "=" and bracket_depth == 0:
+                    assignment_count += 1
+                    equals_count += 1
+                elif "=" in token.string and bracket_depth == 0:
+                    equals_count += 1
+        except tokenize.TokenError:
+            pass
+
+        return assignment_count, equals_count, bracket_delta
+
+    @classmethod
     def inspect(cls, parameters_cell):
         """Inspect the parameters cell to get a Parameter list
 
@@ -238,19 +269,21 @@ class PythonTranslator(Translator):
         # line definition
         grouped_variable = []
         accumulator = []
+        continuation_depth = 0
         for iline, line in enumerate(src.splitlines()):
             if len(line.strip()) == 0 or line.strip().startswith('#'):
                 continue  # Skip blank and comment
 
-            nequal = line.count("=")
-            if nequal > 0:
+            nassign, nequal, bracket_delta = cls._count_top_level_assignments(line)
+            if continuation_depth == 0 and nassign > 0:
                 grouped_variable.append(flatten_accumulator(accumulator))
                 accumulator = []
-                if nequal > 1:
+                if nassign > 1 or nequal > nassign:
                     logger.warning(f"Unable to parse line {iline + 1} '{line}'.")
                     continue
 
             accumulator.append(line)
+            continuation_depth = max(0, continuation_depth + bracket_delta)
         grouped_variable.append(flatten_accumulator(accumulator))
 
         for definition in grouped_variable:


### PR DESCRIPTION
## Summary
- Use Python tokenization when inspecting parameter cells so `=` inside string literals or nested calls is not mistaken for another assignment.
- Preserve the existing behavior of skipping non-introspectable top-level comparisons and multiple assignments.
- Add regression coverage for `msg = a=b` and execution-time unknown-parameter warnings.

Fixes #864

## Tests
- `.\.venv\Scripts\python.exe -m pytest papermill/tests/test_translators.py papermill/tests/test_inspect.py papermill/tests/test_execute.py::TestNotebookHelpers -q` (297 passed)
- Attempted broader local suite. Full collection needs missing optional cloud deps (`azure`, `boto3`); excluding those, 513 passed with 6 environment/backend failures in unrelated GCS/HDFS/kernel-output tests.