### PR TITLE
docs: add CITATION.cff and citing instructions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use papermill in your research, please cite it as below."
+authors:
+  - family-names: "nteract team"
+    given-names: ""
+    affiliation: "nteract"
+title: "papermill: Parameterize, execute, and analyze Jupyter Notebooks"
+version: 2.7.0
+date-released: 2025
+url: "https://github.com/nteract/papermill"
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "nteract team"
+    given-names: ""
+  title: "Papermill: Parameterizing and Executing Jupyter Notebooks"
+  doi: "10.21105/joss.03518"
+  journal: "Journal of Open Source Software"
+  year: 2021

--- a/README.md
+++ b/README.md
@@ -168,6 +168,23 @@ Read [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to setup a local
 
 For development guidelines look in the [DEVELOPMENT_GUIDE.md](./DEVELOPMENT_GUIDE.md) file. This should inform you on how to make particular additions to the code base.
 
+## Citing
+
+If you use papermill in academic work, please cite it as:
+
+```bibtex
+@software{papermill,
+  author = {{nteract team}},
+  title = {papermill: Parameterize, execute, and analyze Jupyter Notebooks},
+  doi = {10.21105/joss.03518},
+  url = {https://github.com/nteract/papermill},
+  version = {2.7.0},
+  year = {2025}
+}
+```
+
+A `CITATION.cff` file is also available in the repository root.
+
 ## Documentation
 
 We host the [Papermill documentation](http://papermill.readthedocs.io)


### PR DESCRIPTION
Closes #881

Adds a CITATION.cff file and a Citing section to the README with BibTeX format for academic attribution.