### PR TITLE
Suppress kernel startup stdout during execution

### DIFF
--- a/papermill/clientwrap.py
+++ b/papermill/clientwrap.py
@@ -1,5 +1,7 @@
 import asyncio
 import sys
+from contextlib import redirect_stdout
+from io import StringIO
 
 from nbclient import NotebookClient
 from nbclient.exceptions import CellExecutionError
@@ -40,7 +42,7 @@ class PapermillNotebookClient(NotebookClient):
         if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-        with self.setup_kernel(**kwargs):
+        with redirect_stdout(StringIO()), self.setup_kernel(**kwargs):
             self.log.info(f"Executing notebook with kernel: {self.kernel_name}")
             self.papermill_execute_cells()
             info_msg = self.wait_for_reply(self.kc.kernel_info())

--- a/papermill/tests/test_clientwrap.py
+++ b/papermill/tests/test_clientwrap.py
@@ -1,4 +1,6 @@
 import unittest
+from contextlib import contextmanager
+from io import StringIO
 from unittest.mock import call, patch
 
 import nbformat
@@ -37,3 +39,23 @@ class TestPapermillClientWrapper(unittest.TestCase):
                     call("<matplotlib.figure.Figure at 0x7f830af7b350>"),
                 ]
             )
+
+    def test_kernel_startup_stdout_does_not_leak_to_parent_stdout(self):
+        @contextmanager
+        def noisy_kernel_setup(**kwargs):
+            print("Starting kernel...")
+            yield
+
+        self.client.kc = unittest.mock.Mock()
+        self.client.kc.kernel_info.return_value = 'kernel-info'
+
+        with (
+            patch.object(self.client, 'setup_kernel', noisy_kernel_setup),
+            patch.object(self.client, 'papermill_execute_cells'),
+            patch.object(self.client, 'wait_for_reply', return_value={'content': {'language_info': {}}}),
+            patch.object(self.client, 'set_widgets_metadata'),
+            patch('sys.stdout', new_callable=StringIO) as stdout,
+        ):
+            self.client.execute()
+
+        self.assertEqual(stdout.getvalue(), "")


### PR DESCRIPTION
## Summary

Fixes #899.

Some kernels can write startup messages directly to the parent process' stdout while nbclient starts the kernel. When Papermill is writing the executed notebook JSON to stdout, that message can be prepended before the notebook content and make the output invalid JSON.

This keeps parent stdout quiet while the kernel context is active. Notebook stream output is still handled through Papermill's existing `log_output`, `stdout_file`, and notebook output paths.

## Tests

- `python -m pytest papermill/tests/test_clientwrap.py papermill/tests/test_cli.py -q`
- `python -m black --check --skip-string-normalization papermill/clientwrap.py papermill/tests/test_clientwrap.py`
- `python -m ruff check papermill/clientwrap.py papermill/tests/test_clientwrap.py`
- `python -m ruff format --check papermill/clientwrap.py papermill/tests/test_clientwrap.py`
- `pre-commit run --files papermill/clientwrap.py papermill/tests/test_clientwrap.py`
- `git diff --check HEAD~1..HEAD`
