### PR TITLE
docs: add papermill-tenki as a real-world remote-execution engine example

### DIFF
--- a/docs/extending-entry-points.rst
+++ b/docs/extending-entry-points.rst
@@ -311,6 +311,10 @@ same ``papermill.engine`` entry point described above::
     pip install papermill-tenki
     papermill input.ipynb output.ipynb --engine tenki
 
+Because it runs against the Tenki service, it needs a Tenki account and the
+``TENKI_API_KEY`` and ``TENKI_PROJECT_ID`` environment variables set; see the
+`papermill-tenki`_ README for setup.
+
 .. _`entry points`: https://packaging.python.org/specifications/entry-points/
 .. _`papermill-tenki`: https://github.com/darolpz-luxor/papermill-tenki
 .. _`Tenki Sandbox`: https://tenki.cloud/docs/sandbox/quick-start-sandbox

--- a/docs/extending-entry-points.rst
+++ b/docs/extending-entry-points.rst
@@ -299,7 +299,21 @@ engine. As you can see, this adds our "injected" output to each code cell
 
 .. image:: img/custom_execution_engine.png
 
+A real-world engine: remote execution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The timing engine above is intentionally minimal. For an engine that executes
+notebooks on remote infrastructure, see `papermill-tenki`_, which runs each
+notebook inside a disposable `Tenki Sandbox`_ microVM and returns the executed
+notebook with its outputs. It installs from PyPI and is discovered through the
+same ``papermill.engine`` entry point described above::
+
+    pip install papermill-tenki
+    papermill input.ipynb output.ipynb --engine tenki
+
 .. _`entry points`: https://packaging.python.org/specifications/entry-points/
+.. _`papermill-tenki`: https://github.com/darolpz-luxor/papermill-tenki
+.. _`Tenki Sandbox`: https://tenki.cloud/docs/sandbox/quick-start-sandbox
 .. |nbformat.NotebookNode| replace:: ``nbformat.NotebookNode`` object
 .. _nbformat.NotebookNode: https://nbformat.readthedocs.io/en/latest/api.html#notebooknode-objects
 .. _`notebook node object`: https://nbformat.readthedocs.io/en/latest/api.html#module-nbformat.v4


### PR DESCRIPTION
## What does this PR do?

Adds a short "real-world engine" subsection to `docs/extending-entry-points.rst`,
pointing readers to [papermill-tenki](https://github.com/darolpz-luxor/papermill-tenki)
as an example of an engine that executes notebooks on remote infrastructure
(disposable Tenki Sandbox microVMs), discovered through the same
`papermill.engine` entry point the surrounding docs already describe.

The existing example engine is intentionally minimal (it just times cells). This
gives readers a concrete, installable example of a non-trivial engine — one that
runs notebooks off-machine and returns the executed notebook with outputs.

Docs-only change; no code or behavior changes. The example notes it requires a
Tenki account and `TENKI_API_KEY` / `TENKI_PROJECT_ID`, linking to the package
README for setup.

No associated issue (docs enhancement).